### PR TITLE
Fixes

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -7,6 +7,9 @@ About
 The ``XGI`` library provides data structures and algorithms for modeling and analyzing
 complex systems with group (higher-order) interactions.
 
+-  Repository: https://github.com/ComplexGroupInteractions/xgi
+-  PyPI: https://pypi.org/project/xgi/
+
 Install
 -------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ XGI
 Description
 -----------
 
-The `XGI`_ library provides data structures and algorithms for modeling and analyzing
+The <`XGI` https://github.com/ComplexGroupInteractions/xgi>_ library provides data structures and algorithms for modeling and analyzing
 complex systems with group (higher-order) interactions.
 
 .. raw:: latex

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ XGI
 Description
 -----------
 
-The <`XGI` https://github.com/ComplexGroupInteractions/xgi>_ library provides data structures and algorithms for modeling and analyzing
+The `XGI <https://github.com/ComplexGroupInteractions/xgi>`_ library provides data structures and algorithms for modeling and analyzing
 complex systems with group (higher-order) interactions.
 
 .. raw:: latex

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ and analysis of complex systems with group (higher-order) interactions."""
 with open("long_description.rst") as file:
     long_description = file.read()
 
+
 def parse_requirements_file(filename):
     with open(filename) as fid:
         requires = [l.strip() for l in fid.readlines() if not l.startswith("#")]

--- a/tests/generators/test_classic.py
+++ b/tests/generators/test_classic.py
@@ -1,5 +1,6 @@
 import xgi
 
+
 def test_empty_hypergraph():
     H = xgi.empty_hypergraph()
     assert H.shape == (0, 0)

--- a/tests/generators/test_nonuniform.py
+++ b/tests/generators/test_nonuniform.py
@@ -5,14 +5,18 @@ from xgi.exception import XGIError
 
 
 def test_erdos_renyi_hypergraph():
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         H = xgi.erdos_renyi_hypergraph(10, 20, -0.1)
-    with pytest.raises(XGIError):
-        H = xgi.erdos_renyi_hypergraph(10, 20, 0.0)
-    with pytest.raises(XGIError):
-        H = xgi.erdos_renyi_hypergraph(10, 20, 1.0)
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         H = xgi.erdos_renyi_hypergraph(10, 20, 2.0)
+
+    H = xgi.erdos_renyi_hypergraph(10, 20, 0.0)
+    assert H.number_of_nodes() == 10
+    assert H.number_of_edges() == 0
+    
+    H = xgi.erdos_renyi_hypergraph(10, 20, 1.0)
+    assert H.number_of_nodes() == 10
+    assert H.number_of_edges() == 20
 
     H = xgi.erdos_renyi_hypergraph(10, 20, 0.1)
     assert H.number_of_nodes() == 10

--- a/tests/generators/test_nonuniform.py
+++ b/tests/generators/test_nonuniform.py
@@ -1,0 +1,30 @@
+import xgi
+import pytest
+
+from xgi.exception import XGIError
+
+
+def test_erdos_renyi_hypergraph():
+    with pytest.raises(XGIError):
+        H = xgi.erdos_renyi_hypergraph(10, 20, -0.1)
+    with pytest.raises(XGIError):
+        H = xgi.erdos_renyi_hypergraph(10, 20, 0.0)
+    with pytest.raises(XGIError):
+        H = xgi.erdos_renyi_hypergraph(10, 20, 1.0)
+    with pytest.raises(XGIError):
+        H = xgi.erdos_renyi_hypergraph(10, 20, 2.0)
+
+    H = xgi.erdos_renyi_hypergraph(10, 20, 0.1)
+    assert H.number_of_nodes() == 10
+
+
+def test_chung_lu_hypergraph():
+    k1 = {1: 1, 2: 2, 3: 3, 4: 4}
+    k2 = {1: 2, 2: 2, 3: 3, 4: 3}
+    H = xgi.chung_lu_hypergraph(k1, k2)
+    assert H.number_of_nodes() == 4
+
+    with pytest.warns(Warning):
+        k1 = {1: 1, 2: 2}
+        k2 = {1: 2, 1: 2}
+        H = xgi.chung_lu_hypergraph(k1, k2)

--- a/tests/generators/test_uniform.py
+++ b/tests/generators/test_uniform.py
@@ -15,3 +15,4 @@ def test_uniform_configuration_model_hypergraph():
         m = 3
         k = {1: 1, 2: 6}
         H = xgi.uniform_hypergraph_configuration_model(k, m)
+    assert sum(dict(H.degree).values()) % m == 0

--- a/tests/generators/test_uniform.py
+++ b/tests/generators/test_uniform.py
@@ -1,2 +1,17 @@
 import xgi
 from xgi.exception import XGIError
+import pytest
+
+
+def test_uniform_configuration_model_hypergraph():
+    m = 3
+    k = {1: 1, 2: 2, 3: 3, 4: 3}
+    H = xgi.uniform_hypergraph_configuration_model(k, m)
+    assert H.number_of_nodes() == 4
+    assert dict(H.degree) == k
+    assert H.number_of_edges() == 3
+
+    with pytest.warns(Warning):
+        m = 3
+        k = {1: 1, 2: 6}
+        H = xgi.uniform_hypergraph_configuration_model(k, m)

--- a/xgi/generators/nonuniform.py
+++ b/xgi/generators/nonuniform.py
@@ -51,8 +51,20 @@ def erdos_renyi_hypergraph(n, m, p):
     H = xgi.empty_hypergraph()
     H.add_nodes_from(range(n))
 
-    if p <= 0.0 or p >= 1.0:
-        raise XGIError("Invalid p value.")
+    if p < 0.0 or p > 1.0:
+        raise ValueError("Invalid p value.")
+    
+    if p == 0.0:
+        H = xgi.empty_hypergraph()
+        H.add_nodes_from(range(n))
+        return H
+    
+    # this corresponds to a completely filled incidence matrix,
+    # not a complete hypergraph.
+    if p == 1.0:
+        H = xgi.empty_hypergraph()
+        H.add_edges_from([range(n) for i in range(m)])
+        return H
 
     for u in range(n):
         v = 0
@@ -63,8 +75,7 @@ def erdos_renyi_hypergraph(n, m, p):
             if v < m:
                 # add vertex hyperedge pair
                 H.add_node_to_edge(v, u)
-                v = v + 1
-
+            v = v + 1
     return H
 
 

--- a/xgi/readwrite/bipartite.py
+++ b/xgi/readwrite/bipartite.py
@@ -139,7 +139,8 @@ def parse_bipartite_edgelist(
         The token that denotes comments to ignore
     delimiter: char, default: space (" ")
         Specifies the delimiter between hyperedge members
-    create_using:
+    create_using : Hypergraph constructor, optional
+        The hypergraph object to add the data to, by default None
     nodetype: type
         type that the node labels will be cast to
     data: bool, default: False
@@ -159,12 +160,8 @@ def parse_bipartite_edgelist(
     """
     H = xgi.empty_hypergraph(create_using)
 
-    if dual:
-        node_index = 1
-        edge_index = 0
-    else:
-        node_index = 0
-        edge_index = 1
+    node_index = 1 if dual else 0
+    edge_index = 0 if dual else 1
 
     for line in lines:
         if comments is not None:

--- a/xgi/readwrite/bipartite.py
+++ b/xgi/readwrite/bipartite.py
@@ -28,7 +28,7 @@ def generate_bipartite_edgelist(H, delimiter=" "):
             yield delimiter.join(map(str, [node, id]))
 
 
-def write_bipartite_edgelist(H, path, delimiter=" ", data=True, encoding="utf-8"):
+def write_bipartite_edgelist(H, path, delimiter=" ", encoding="utf-8"):
     """Write a Hypergraph object to a file
     as a bipartite edgelist.
 
@@ -40,8 +40,6 @@ def write_bipartite_edgelist(H, path, delimiter=" ", data=True, encoding="utf-8"
         The path of the file to write to
     delimiter: char, default: space (" ")
         Specifies the delimiter between hyperedge members
-    data: bool, default: True
-        Specifies whether to output the edge attributes
     encoding: string, default: "utf-8"
         Encoding of the file
 
@@ -70,7 +68,7 @@ def read_bipartite_edgelist(
     delimiter=None,
     create_using=None,
     nodetype=None,
-    data=False,
+    dual=False,
     encoding="utf-8",
 ):
     """Read a file containing a bipartite edge list and
@@ -88,8 +86,9 @@ def read_bipartite_edgelist(
         The hypergraph object to add the data to, by default None
     nodetype: type
         type that the node labels will be cast to
-    data: bool, default: False
-        Specifies whether there is a dictionary of data at the end of the line.
+    dual: bool, default: False
+        Specifies whether the node IDs are in the second column. If False,
+        the node IDs are in the first column.
     encoding: string, default: "utf-8"
         Encoding of the file
 
@@ -117,11 +116,12 @@ def read_bipartite_edgelist(
             delimiter=delimiter,
             create_using=create_using,
             nodetype=nodetype,
+            dual=dual,
         )
 
 
 def parse_bipartite_edgelist(
-    lines, comments="#", delimiter=None, create_using=None, nodetype=None
+    lines, comments="#", delimiter=None, create_using=None, nodetype=None, dual=False
 ):
     """
     A helper function to read a iterable of strings containing a bipartite edge list and
@@ -158,6 +158,14 @@ def parse_bipartite_edgelist(
         The loaded hypergraph
     """
     H = xgi.empty_hypergraph(create_using)
+
+    if dual:
+        node_index = 1
+        edge_index = 0
+    else:
+        node_index = 0
+        edge_index = 1
+
     for line in lines:
         if comments is not None:
             p = line.find(comments)
@@ -172,9 +180,9 @@ def parse_bipartite_edgelist(
 
         if nodetype is not None:
             try:
-                H.add_node_to_edge(s[1], nodetype(s[0]))
+                H.add_node_to_edge(s[edge_index], nodetype(s[node_index]))
             except Exception as e:
                 raise TypeError(f"Failed to convert nodes to type {nodetype}.") from e
         else:
-            H.add_node_to_edge(s[1], s[0])
+            H.add_node_to_edge(s[edge_index], s[node_index])
     return H


### PR DESCRIPTION
This issue closes #27 and closes #24. This PR implements the following:

* Fixes the `erdos_renyi_hypergraph()`, `chung_lu_hypergraph()`, and `dcsbm_hypergraph()` methods such that the number of nodes will always match the numberthe user specifies, even if the resulting hypergraph is disconnected.
* Changed the construction method from reading in a Pandas DataFrame to using the `add_node_to_edge()` method for a 2x speedup.
* Added some basic unit tests for the generative models.
* Added the `dual` keyword for the `read_bipartite_edgelist()` method.