### PR TITLE
Refactor core interface

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,16 @@ authors:
   -
     family-names: Torres
     given-names: Leo
+  -
+    family-names: Iacopini
+    given-names: Iacopo
+  -
+    family-names: Lucas
+    given-names: Maxime
+  -
+    family-names: Petri
+    given-names: Giovanni
+
 cff-version: "1.1.0"
 license: "BSD-3"
 message: "If you use this software, please cite it using these metadata."

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,11 @@
 XGI is distributed with the 3-clause BSD license.
 
-Copyright (C) 2021, Hypergraph Developers
+Copyright (C) 2021, XGI Developers
 Nicholas Landry <nicholas.landry.91@gmail.com>
 Leo Torres <leo@leotrs.com>
+Iacopo Iacopini <iacopiniiacopo@gmail.com>
+Maxime Lucas <maxime.lucas@isi.it>
+Giovanni Petri <giovanni.petri@isi.it>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/tests/classes/test_function.py
+++ b/tests/classes/test_function.py
@@ -80,15 +80,16 @@ def test_create_empty_copy(edgelist1):
 
     assert E1.shape == (8, 0)
     for node in E1.nodes:
-        assert len(E1.nodes[node]) == 0
+        assert len(E1.nodes.membership(node)) == 0
     assert E1.name == ""
     assert E1._hypergraph == {}
 
     assert E2.shape == (8, 0)
     for node in E2.nodes:
-        assert len(E1.nodes[node]) == 0
+        assert len(E1.nodes.membership(node)) == 0
     assert E2._hypergraph == {"name": "test", "timestamp": "Nov. 20"}
-    assert dict(E2.nodes.data()) == attr_dict
+    for n in H.nodes:
+        assert H.nodes[n]["name"] == attr_dict[n]["name"]
 
 
 def test_is_empty():

--- a/tests/classes/test_function.py
+++ b/tests/classes/test_function.py
@@ -81,7 +81,6 @@ def test_create_empty_copy(edgelist1):
     assert E1.shape == (8, 0)
     for node in E1.nodes:
         assert len(E1.nodes.memberships(node)) == 0
-    assert E1.name == ""
     assert E1._hypergraph == {}
 
     assert E2.shape == (8, 0)

--- a/tests/classes/test_function.py
+++ b/tests/classes/test_function.py
@@ -80,13 +80,13 @@ def test_create_empty_copy(edgelist1):
 
     assert E1.shape == (8, 0)
     for node in E1.nodes:
-        assert len(E1.nodes.membership(node)) == 0
+        assert len(E1.nodes.memberships(node)) == 0
     assert E1.name == ""
     assert E1._hypergraph == {}
 
     assert E2.shape == (8, 0)
     for node in E2.nodes:
-        assert len(E1.nodes.membership(node)) == 0
+        assert len(E1.nodes.memberships(node)) == 0
     assert E2._hypergraph == {"name": "test", "timestamp": "Nov. 20"}
     for n in H.nodes:
         assert H.nodes[n]["name"] == attr_dict[n]["name"]

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -1,5 +1,6 @@
 import pytest
 import xgi
+from xgi.exception import XGIError
 
 
 def test_constructor(edgelist5, dict5, incidence5, dataframe5):
@@ -169,7 +170,7 @@ def test_add_node_attr(edgelist1):
 
 def test_hypergraph_attr(edgelist1):
     H = xgi.Hypergraph(edgelist1)
-    with pytest.raises(KeyError):
+    with pytest.raises(XGIError):
         H['color']
     H['color'] = 'red'
     assert H['color'] == 'red'

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -173,3 +173,12 @@ def test_hypergraph_attr(edgelist1):
         H['color']
     H['color'] = 'red'
     assert H['color'] == 'red'
+
+
+def test_members(edgelist1):
+    H = xgi.Hypergraph(edgelist1)
+    assert H.nodes.members(1) == H.nodes.membership(1) == [0]
+    assert H.nodes.members(2) == H.nodes.membership(2) == [0]
+    assert H.nodes.members(3) == H.nodes.membership(3) == [0]
+    assert H.nodes.members(4) == H.nodes.membership(4) == [1]
+    assert H.nodes.members(6) == H.nodes.membership(6) == [2, 3]

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -22,10 +22,10 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
         == list(H_df.edges)
     )
     assert (
-        list(H_list.edges[0])
-        == list(H_dict.edges[0])
-        == list(H_mat.edges[0])
-        == list(H_df.edges[0])
+        list(H_list.edges.members(0))
+        == list(H_dict.edges.members(0))
+        == list(H_mat.edges.members(0))
+        == list(H_df.edges.members(0))
     )
 
 

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -103,7 +103,7 @@ def test_max_edge_order(edgelist1, edgelist4,edgelist5):
 
     assert H0.max_edge_order() == None
     assert H1.max_edge_order() == 0
-    assert H2.max_edge_order() == 2 
+    assert H2.max_edge_order() == 2
     assert H3.max_edge_order() == 3
     assert H4.max_edge_order() == 3
 
@@ -112,7 +112,7 @@ def test_is_possible_order(edgelist1):
     H1 = xgi.Hypergraph(edgelist1)
 
     assert H1.is_possible_order(-1) == False
-    assert H1.is_possible_order(0) == False 
+    assert H1.is_possible_order(0) == False
     assert H1.is_possible_order(1) == True
     assert H1.is_possible_order(2) == True
     assert H1.is_possible_order(3) == False
@@ -143,8 +143,8 @@ def test_is_uniform(edgelist1, edgelist6, edgelist7):
     H2 = xgi.Hypergraph(edgelist7)
     H3 = xgi.empty_hypergraph()
 
-    assert H0.is_uniform() == False 
-    assert H1.is_uniform() == 2 
+    assert H0.is_uniform() == False
+    assert H1.is_uniform() == 2
     assert H2.is_uniform() == 2
     assert H3.is_uniform() == False
 

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -30,13 +30,13 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
     )
 
 
-def test_name():
+def test_hypergraph_attrs():
     H = xgi.Hypergraph()
-    assert H.name == ""
-    H.name = "test"
-    assert H.name == "test"
+    assert H._hypergraph == dict()
+    with pytest.raises(XGIError):
+        name = H["name"]
     H = xgi.Hypergraph(name="test")
-    assert H.name == "test"
+    assert H["name"] == "test"
 
 
 def test_contains(edgelist1):
@@ -48,6 +48,12 @@ def test_contains(edgelist1):
 
     assert 0 not in H
 
+def test_string():
+    H1 = xgi.Hypergraph()
+    assert str(H1) == "Unnamed Hypergraph with 0 nodes and 0 hyperedges"
+    H2 = xgi.Hypergraph(name="test")
+    # H2["name"] = "test"
+    assert str(H2) == "Hypergraph named test with 0 nodes and 0 hyperedges"
 
 def test_len(edgelist1, edgelist2):
     el1 = edgelist1

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -155,3 +155,12 @@ def test_isolates(edgelist1):
     assert H.isolates() == {4}
     H.remove_isolates()
     assert 4 not in H
+
+
+def test_add_node_atr(edgelist1):
+    H = xgi.Hypergraph(edgelist1)
+    assert 'new_node' not in H
+    H.add_node('new_node', color='red')
+    assert 'new_node' in H
+    assert 'color' in H.node['new_node']
+    assert H.node['new_node']['color'] == 'red'

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -1,3 +1,4 @@
+import pytest
 import xgi
 
 
@@ -157,10 +158,18 @@ def test_isolates(edgelist1):
     assert 4 not in H
 
 
-def test_add_node_atr(edgelist1):
+def test_add_node_attr(edgelist1):
     H = xgi.Hypergraph(edgelist1)
     assert 'new_node' not in H
     H.add_node('new_node', color='red')
     assert 'new_node' in H
-    assert 'color' in H.node['new_node']
-    assert H.node['new_node']['color'] == 'red'
+    assert 'color' in H.nodes['new_node']
+    assert H.nodes['new_node']['color'] == 'red'
+
+
+def test_hypergraph_attr(edgelist1):
+    H = xgi.Hypergraph(edgelist1)
+    with pytest.raises(KeyError):
+        H['color']
+    H['color'] = 'red'
+    assert H['color'] == 'red'

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -178,8 +178,8 @@ def test_hypergraph_attr(edgelist1):
 
 def test_members(edgelist1):
     H = xgi.Hypergraph(edgelist1)
-    assert H.nodes.members(1) == H.nodes.memberships(1) == [0]
-    assert H.nodes.members(2) == H.nodes.memberships(2) == [0]
-    assert H.nodes.members(3) == H.nodes.memberships(3) == [0]
-    assert H.nodes.members(4) == H.nodes.memberships(4) == [1]
-    assert H.nodes.members(6) == H.nodes.memberships(6) == [2, 3]
+    assert H.nodes.memberships(1) == [0]
+    assert H.nodes.memberships(2) == [0]
+    assert H.nodes.memberships(3) == [0]
+    assert H.nodes.memberships(4) == [1]
+    assert H.nodes.memberships(6) == [2, 3]

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -183,3 +183,7 @@ def test_members(edgelist1):
     assert H.nodes.memberships(3) == [0]
     assert H.nodes.memberships(4) == [1]
     assert H.nodes.memberships(6) == [2, 3]
+    with pytest.raises(XGIError):
+        H.nodes.memberships(0)
+    with pytest.raises(XGIError):
+        H.nodes.memberships(slice(1, 4))

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -95,7 +95,7 @@ def test_dual(edgelist1, edgelist2, edgelist4):
     assert D3.shape == (3, 5)
 
 
-def test_max_edge_order(edgelist1, edgelist4,edgelist5):
+def test_max_edge_order(edgelist1, edgelist4, edgelist5):
     H0 = xgi.empty_hypergraph()
     H1 = xgi.empty_hypergraph()
     H1.add_nodes_from(range(5))
@@ -124,7 +124,7 @@ def test_singleton_edges(edgelist1, edgelist2):
     H1 = xgi.Hypergraph(edgelist1)
     H2 = xgi.Hypergraph(edgelist2)
 
-    assert H1.singleton_edges() == {1 : [4]}
+    assert H1.singleton_edges() == {1: [4]}
     assert H2.singleton_edges() == {}
 
 
@@ -161,25 +161,25 @@ def test_isolates(edgelist1):
 
 def test_add_node_attr(edgelist1):
     H = xgi.Hypergraph(edgelist1)
-    assert 'new_node' not in H
-    H.add_node('new_node', color='red')
-    assert 'new_node' in H
-    assert 'color' in H.nodes['new_node']
-    assert H.nodes['new_node']['color'] == 'red'
+    assert "new_node" not in H
+    H.add_node("new_node", color="red")
+    assert "new_node" in H
+    assert "color" in H.nodes["new_node"]
+    assert H.nodes["new_node"]["color"] == "red"
 
 
 def test_hypergraph_attr(edgelist1):
     H = xgi.Hypergraph(edgelist1)
     with pytest.raises(XGIError):
-        H['color']
-    H['color'] = 'red'
-    assert H['color'] == 'red'
+        H["color"]
+    H["color"] = "red"
+    assert H["color"] == "red"
 
 
 def test_members(edgelist1):
     H = xgi.Hypergraph(edgelist1)
-    assert H.nodes.members(1) == H.nodes.membership(1) == [0]
-    assert H.nodes.members(2) == H.nodes.membership(2) == [0]
-    assert H.nodes.members(3) == H.nodes.membership(3) == [0]
-    assert H.nodes.members(4) == H.nodes.membership(4) == [1]
-    assert H.nodes.members(6) == H.nodes.membership(6) == [2, 3]
+    assert H.nodes.members(1) == H.nodes.memberships(1) == [0]
+    assert H.nodes.members(2) == H.nodes.memberships(2) == [0]
+    assert H.nodes.members(3) == H.nodes.memberships(3) == [0]
+    assert H.nodes.members(4) == H.nodes.memberships(4) == [1]
+    assert H.nodes.members(6) == H.nodes.memberships(6) == [2, 3]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,14 +30,16 @@ def edgelist4():
 @pytest.fixture
 def edgelist5():
     return [[0, 1, 2, 3], [4], [5, 6], [6, 7, 8]]
-    
+
+
 @pytest.fixture
 def edgelist6():
     return [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
-    
+
+
 @pytest.fixture
 def edgelist7():
-    return [[0, 1, 2], [1, 2, 3], [2, 3, 4], [4]]    
+    return [[0, 1, 2], [1, 2, 3], [2, 3, 4], [4]]
 
 
 @pytest.fixture

--- a/tests/generators/test_nonuniform.py
+++ b/tests/generators/test_nonuniform.py
@@ -13,7 +13,7 @@ def test_erdos_renyi_hypergraph():
     H = xgi.erdos_renyi_hypergraph(10, 20, 0.0)
     assert H.number_of_nodes() == 10
     assert H.number_of_edges() == 0
-    
+
     H = xgi.erdos_renyi_hypergraph(10, 20, 1.0)
     assert H.number_of_nodes() == 10
     assert H.number_of_edges() == 20
@@ -32,4 +32,3 @@ def test_chung_lu_hypergraph():
         k1 = {1: 1, 2: 2}
         k2 = {1: 2, 1: 2}
         H = xgi.chung_lu_hypergraph(k1, k2)
-

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -64,7 +64,7 @@ def unique_edge_sizes(H, return_counts=False):
     list()
         The unique edge sizes
     """
-    return list({len(H.edges[edge]) for edge in H.edges})
+    return list({len(H.edges.members(edge)) for edge in H.edges})
 
 
 def frozen(*args, **kwargs):

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -198,7 +198,7 @@ def create_empty_copy(H, with_data=True):
     H_copy = H.__class__()
     H_copy.add_nodes_from(H.nodes)
     if with_data:
-        xgi.set_node_attributes(H_copy, dict(H.nodes.data()))
+        xgi.set_node_attributes(H_copy, dict(H._node_attr))
         H_copy._hypergraph.update(H._hypergraph)
     return H_copy
 
@@ -251,7 +251,7 @@ def set_node_attributes(H, values, name=None):
         try:  # `values` is a dict
             for n, v in values.items():
                 try:
-                    H._node_attr[n][name] = values[n]
+                    H._node_attr[n][name] = v
                 except KeyError:
                     pass
         except AttributeError:  # `values` is a constant
@@ -362,7 +362,7 @@ def get_edge_attributes(H, name):
     get_node_attributes
     set_edge_attributes
     """
-    edge_data = H.edges.data
+    edge_data = H._edge_attr
     return {id: edge_data[edge][name] for edge in edge_data if name in edge_data[edge]}
 
 

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -1242,8 +1242,8 @@ class Hypergraph:
         all edges in the hypergraph (excluding singletons, i.e. nodes)
         have the same degree d. Returns d=None if not uniform.
 
-        This function can be used as a boolean check: 
-        >>> if H.is_uniform() 
+        This function can be used as a boolean check:
+        >>> if H.is_uniform()
         works as expected.
 
         Returns:
@@ -1267,4 +1267,4 @@ class Hypergraph:
             else:
                 d = False
 
-        return d 
+        return d

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -287,7 +287,7 @@ class Hypergraph:
         remove_nodes_from
         """
         try:
-            edge_neighbors = self.nodes[n]  # list handles self-loops (allows mutation)
+            edge_neighbors = self._node[n]  # list handles self-loops (allows mutation)
             del self._node[n]
             del self._node_attr[n]
         except KeyError as e:  # XGIError if n not in self
@@ -314,9 +314,8 @@ class Hypergraph:
         """
         for n in nodes:
             try:
-                edge_neighbors = self.nodes[
-                    n
-                ]  # list handles self-loops (allows mutation)
+                edge_neighbors = self._node[n] 
+                # list handles self-loops (allows mutation)
                 del self._node[n]
                 del self._node_attr[n]
                 for edge in edge_neighbors:
@@ -635,7 +634,7 @@ class Hypergraph:
         remove_edges_from : remove a collection of edges
         """
         try:
-            for node in self.edges[id]:
+            for node in self.edges.members(id):
                 self._node[node].remove(id)
             del self._edge[id]
             del self._edge_attr[id]
@@ -661,7 +660,7 @@ class Hypergraph:
         """
         for id in ebunch:
             try:
-                for node in self.edges[id]:
+                for node in self.edges.members(id):
                     self._node[node].remove(id)
                 del self._edge[id]
                 del self._edge_attr[id]
@@ -799,7 +798,9 @@ class Hypergraph:
             The edge attribute dictionary.
         """
         try:
-            return self.edges.data(id, default=default)
+             # this may fail because the ID may not exist
+             # or the property doesn't exist.
+            return self.edges[id]
         except KeyError:
             return default
 

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -242,8 +242,7 @@ class Hypergraph:
                 raise ValueError("None cannot be a node")
             self._node[node_for_adding] = list()
             self._node_attr[node_for_adding] = self.node_attr_dict_factory()
-        else:  # update attr even if node already exists
-            self._node_attr[node_for_adding].update(attr)
+        self._node_attr[node_for_adding].update(attr)
 
     def add_nodes_from(self, nodes_for_adding, **attr):
         """Add multiple nodes.

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -51,14 +51,7 @@ class Hypergraph:
         """
         self._edge_uid = XGICounter()
 
-        self.hypergraph_attr_dict_factory = self.hypergraph_attr_dict_factory
-        self.node_dict_factory = self.node_dict_factory
-        self.node_attr_dict_factory = self.node_attr_dict_factory
-        self.hyperedge_attr_dict_factory = self.hyperedge_attr_dict_factory
-
-        self._hypergraph = (
-            self.hypergraph_attr_dict_factory()
-        )  # dictionary for graph attributes
+        self._hypergraph = self.hypergraph_attr_dict_factory()
         self._node = self.node_dict_factory()  # empty node attribute dict
         self._node_attr = self.node_attr_dict_factory()
         self._edge = self.hyperedge_dict_factory()
@@ -162,19 +155,9 @@ class Hypergraph:
         """
         return len(self._node)
 
-    def __getitem__(self, n):
-        """Returns a list of neighboring edge IDs of node n.  Use: 'H[n]'.
-
-        Returns
-        -------
-        list
-           A list of the edges of which the specified node is a part.
-
-        Notes
-        -----
-        H[n] is the same as H.nodes[n]
-        """
-        return self._node[n]
+    def __getitem__(self, attr):
+        """Hypergraph attributes."""
+        return self._hypergraph[attr]
 
     @property
     def shape(self):

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -1207,7 +1207,7 @@ class Hypergraph:
         """
         nodes_in_edges = set()
         for idx in self.edges:
-            edge = self.edges(idx)
+            edge = self.edges.members(idx)
             if ignore_singletons and len(edge) == 1:
                 continue
             nodes_in_edges = nodes_in_edges.union(edge)

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -157,7 +157,10 @@ class Hypergraph:
 
     def __getitem__(self, attr):
         """Read hypergraph attribute."""
-        return self._hypergraph.get(attr, "")
+        try:
+            return self._hypergraph[attr]
+        except:
+            raise XGIError("This attribute has not been set.")
 
     def __setitem__(self, attr, val):
         """Write hypergraph attribute."""

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -7,7 +7,6 @@ Multiedges and self-loops are allowed.
 """
 from copy import deepcopy
 
-import numpy as np
 import xgi
 import xgi.convert as convert
 from xgi.classes.reportviews import DegreeView, EdgeSizeView, EdgeView, NodeView
@@ -61,32 +60,6 @@ class Hypergraph:
         # load hypergraph attributes (must be after convert)
         self._hypergraph.update(attr)
 
-    @property
-    def name(self):
-        """Get the string identifier of the hypergraph.
-
-        This hypergraph attribute appears in the attribute dict H._hypergraph
-        keyed by the string `"name"`. as well as an attribute (technically
-        a property) `H.name`. This is entirely user controlled.
-
-        Returns
-        -------
-        string
-            The name of the hypergraph
-        """
-        return self._hypergraph.get("name", "")
-
-    @name.setter
-    def name(self, s):
-        """Set the name of the hypergraph
-
-        Parameters
-        ----------
-        s : string
-            The desired name of the hypergraph.
-        """
-        self._hypergraph["name"] = s
-
     def __str__(self):
         """Returns a short summary of the hypergraph.
 
@@ -103,13 +76,10 @@ class Hypergraph:
         "Hypergraph named 'foo' with 0 nodes and 0 edges"
 
         """
-        return "".join(
-            [
-                type(self).__name__,
-                f" named {self.name!r}",
-                f" with {self.number_of_nodes()} nodes and {self.number_of_edges()} hyperedges",
-            ]
-        )
+        try:
+            return f"{type(self).__name__} named {self['name']} with {self.number_of_nodes()} nodes and {self.number_of_edges()} hyperedges"
+        except:
+            return f"Unnamed {type(self).__name__} with {self.number_of_nodes()} nodes and {self.number_of_edges()} hyperedges"
 
     def __iter__(self):
         """Iterate over the nodes. Use: 'for n in H'.
@@ -158,7 +128,7 @@ class Hypergraph:
         """Read hypergraph attribute."""
         try:
             return self._hypergraph[attr]
-        except:
+        except KeyError:
             raise XGIError("This attribute has not been set.")
 
     def __setitem__(self, attr, val):

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -157,7 +157,7 @@ class Hypergraph:
 
     def __getitem__(self, attr):
         """Read hypergraph attribute."""
-        return self._hypergraph[attr]
+        return self._hypergraph.get(attr, "")
 
     def __setitem__(self, attr, val):
         """Write hypergraph attribute."""

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -10,8 +10,7 @@ from copy import deepcopy
 import numpy as np
 import xgi
 import xgi.convert as convert
-from xgi.classes.reportviews import (DegreeView, EdgeSizeView, EdgeView,
-                                     NodeView)
+from xgi.classes.reportviews import DegreeView, EdgeSizeView, EdgeView, NodeView
 from xgi.exception import XGIError
 from xgi.utils import XGICounter
 
@@ -317,7 +316,7 @@ class Hypergraph:
         """
         for n in nodes:
             try:
-                edge_neighbors = self._node[n] 
+                edge_neighbors = self._node[n]
                 # list handles self-loops (allows mutation)
                 del self._node[n]
                 del self._node_attr[n]
@@ -801,8 +800,8 @@ class Hypergraph:
             The edge attribute dictionary.
         """
         try:
-             # this may fail because the ID may not exist
-             # or the property doesn't exist.
+            # this may fail because the ID may not exist
+            # or the property doesn't exist.
             return self.edges[id]
         except KeyError:
             return default
@@ -1255,7 +1254,7 @@ class Hypergraph:
             edge_sizes.remove(1)  # discard singleton edges
 
         if len(edge_sizes) == 0:  # no edges
-            d = False # not uniform
+            d = False  # not uniform
         else:
             uniform = len(edge_sizes) == 1
             if uniform:

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -334,21 +334,14 @@ class Hypergraph:
         """A NodeView of the Hypergraph as H.nodes or H.nodes().
 
         Can be used as `H.nodes` for data lookup and for set-like operations.
-        Can also be used as `H.nodes(data='color', default=None)` to return a
-        NodeDataView which reports specific node data but no set operations.
-        It presents a dict-like interface as well with `H.nodes.items()`
-        iterating over `(node, edge_ids)` 2-tuples. In addition,
-        a view `H.nodes.data('foo')` provides a dict-like interface to the
-        `foo` attribute of each node. `H.nodes.data('foo', default=1)`
-        provides a default for nodes that do not have attribute `foo`.
+        Can also be used as `H.nodes[id]` to return a
+        dictionary of the node attributes.
 
         Returns
         -------
         NodeView
             Allows set-like operations over the nodes as well as node
-            attribute dict lookup and calling to get a NodeDataView.
-            A NodeDataView iterates over `(n, data)` and has no set operations.
-            A NodeView iterates over `n` and includes set operations.
+            attribute dict lookup.
 
             When called, if data is False, an iterator over nodes.
             Otherwise an iterator of 2-tuples (node, attribute value)
@@ -751,14 +744,12 @@ class Hypergraph:
 
     @property
     def edges(self):
-        """An EdgeView of the Hyperraph as H.edges or H.edges().
+        """An EdgeView of the Hypergraph as H.edges or H.edges().
 
         edges(self, nbunch=None, data=False, default=None)
 
         The EdgeView provides set-like operations on the edge IDs
-        as well as edge attribute lookup. When called, it also provides
-        an EdgeDataView object which allows control of access to edge
-        attributes (but does not provide set-like operations).
+        as well as edge attribute lookup.
 
         Parameters
         ----------

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -156,8 +156,12 @@ class Hypergraph:
         return len(self._node)
 
     def __getitem__(self, attr):
-        """Hypergraph attributes."""
+        """Read hypergraph attribute."""
         return self._hypergraph[attr]
+
+    def __setitem__(self, attr, val):
+        """Write hypergraph attribute."""
+        self._hypergraph[attr] = val
 
     @property
     def shape(self):
@@ -769,7 +773,12 @@ class Hypergraph:
         -----
         Nodes in nbunch that are not in the hypergraph will be (quietly) ignored.
         """
-        return EdgeView(self)
+        edges = EdgeView(self)
+        # Lazy View creation: overload the (class) property on the instance
+        # Then future H.edges use the existing View
+        # setattr doesn't work because attribute already exists
+        self.__dict__["edges"] = edges
+        return edges
 
     def get_edge_data(self, id, default=None):
         """Returns the attribute dictionary associated with edge id.

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -152,9 +152,7 @@ class NodeView(Mapping, Set):
         return iter(self._nodes)
 
     def __getitem__(self, n):
-        """Get the edges of which the node is a member.
-
-        Identical to __call__, members
+        """Get the attributes of the node.
 
         Parameters
         ----------
@@ -163,8 +161,8 @@ class NodeView(Mapping, Set):
 
         Returns
         -------
-        list
-            A list of the edge IDs of which the node is a part.
+        dict
+            Node attributes.
 
         Raises
         ------
@@ -172,10 +170,6 @@ class NodeView(Mapping, Set):
             Returns an error if the user tries passing in a slice or if
             the node does not exist in the hypergraph.
 
-        See Also
-        --------
-        __call__
-        members
         """
         if isinstance(n, slice):
             raise XGIError(
@@ -185,7 +179,7 @@ class NodeView(Mapping, Set):
         elif n not in self._nodes:
             raise XGIError(f"The node {n} is not in the hypergraph")
 
-        return self._nodes[n]
+        return self._node_attr[n]
 
     # Set methods
     def __contains__(self, n):
@@ -203,44 +197,8 @@ class NodeView(Mapping, Set):
         """
         return n in self._nodes
 
-    def __call__(self, n):
-        """Handles calling the nodes, i.e. H.nodes(n).
-
-        Identical to __getitem__, members
-
-        Parameters
-        ----------
-        n : hashable
-            node ID
-
-        Returns
-        -------
-        list
-            A list of the edge IDs of which the node is a part.
-
-        Raises
-        ------
-        xgi.XGIError
-            Returns an error if the user tries passing in a slice or if
-            the node does not exist in the hypergraph.
-
-        See Also
-        --------
-        __getitem__
-        members
-        """
-        if isinstance(n, slice):
-            raise XGIError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(H.nodes)[{n.start}:{n.stop}:{n.step}]"
-            )
-        elif n not in self._nodes:
-            raise XGIError(f"The node {n} is not in the hypergraph")
-        return self._nodes[n]
-
     def data(self, data=True, default=None):
-        """
-        Return a read-only view of node data.
+        """Return a read-only view of node data.
 
         Parameters
         ----------
@@ -611,10 +569,8 @@ class EdgeView(Set, Mapping):
         except KeyError:
             return False
 
-    # get edge members
     def __getitem__(self, e):
-        """Get the members of an edge as a list
-        given an edge ID.
+        """Get the attributes of an edge.
 
         Parameters
         ----------
@@ -623,8 +579,8 @@ class EdgeView(Set, Mapping):
 
         Returns
         -------
-        list
-            edge members
+        dict
+            Edge attributes
 
         Raises
         ------
@@ -632,10 +588,6 @@ class EdgeView(Set, Mapping):
             Returns an error if the user tries passing in a slice or if
             the edge ID does not exist in the hypergraph.
 
-        See Also
-        --------
-        __call__
-        members
         """
         if isinstance(e, slice):
             raise XGIError(
@@ -644,42 +596,7 @@ class EdgeView(Set, Mapping):
             )
         elif e not in self._edges:
             raise XGIError(f"The edge {e} is not in the hypergraph")
-        return self._edges[e]
-
-    # get edge members
-    def __call__(self, e):
-        """Get the members of an edge as a list
-        given an edge ID.
-
-        Parameters
-        ----------
-        e : hashable
-            edge ID
-
-        Returns
-        -------
-        list
-            edge members
-
-        Raises
-        ------
-        xgi.XGIError
-            Returns an error if the user tries passing in a slice or if
-            the edge ID does not exist in the hypergraph.
-
-        See Also
-        --------
-        __getitem__
-        members
-        """
-        if isinstance(e, slice):
-            raise XGIError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(H.edges)[{e.start}:{e.stop}:{e.step}]"
-            )
-        elif e not in self._edges:
-            raise XGIError(f"The edge {e} is not in the hypergraph")
-        return self._edges[e]
+        return self._edge_attr[e]
 
     def members(self, e):
         """Get the members of an edge as a list

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -321,13 +321,14 @@ class IDDegreeView:
 
 
 class NodeView(IDView):
-    """ Class for representing the nodes.
+    """Class for representing the nodes.
 
     Much of the functionality in this class inherits from IDView
     """
+
     def __init__(self, hypergraph):
         super(NodeView, self).__init__(hypergraph._node, hypergraph._node_attr)
-    
+
     def memberships(self, n):
         """Get the edges of which a node is a member.
 
@@ -363,16 +364,17 @@ class NodeView(IDView):
 
 
 class EdgeView(IDView):
-    """ Class for representing the edges.
+    """Class for representing the edges.
 
     Much of the functionality in this class inherits from IDView
     """
+
     def __init__(self, hypergraph):
         super(EdgeView, self).__init__(hypergraph._edge, hypergraph._edge_attr)
-    
+
     def members(self, e):
         """Get the nodes that are members of an edge.
-        
+
         Given an edge ID, this method returns the node IDs
         that are members of this edge.
 
@@ -403,11 +405,13 @@ class EdgeView(IDView):
                     f"try list(H.edges)[{e.start}:{e.stop}:{e.step}]"
                 )
 
+
 class DegreeView(IDDegreeView):
-    """ Class for representing the degrees.
+    """Class for representing the degrees.
 
     This class inherits all its functionality from IDDegreeView
     """
+
     def __init__(self, hypergraph, nbunch=None, weight=None):
         super().__init__(
             hypergraph._node, hypergraph._edge_attr, id_bunch=nbunch, weight=weight
@@ -415,10 +419,11 @@ class DegreeView(IDDegreeView):
 
 
 class EdgeSizeView(IDDegreeView):
-    """ Class for representing the edge sizes.
+    """Class for representing the edge sizes.
 
     This class inherits all its functionality from IDDegreeView
     """
+
     def __init__(self, hypergraph, ebunch=None, weight=None):
         super().__init__(
             hypergraph._edge, hypergraph._node_attr, id_bunch=ebunch, weight=weight

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -25,9 +25,9 @@ NodeDataView
 ============
 
     To iterate over (node, data) pairs, use arguments to `H.nodes()`
-    to create a DataView e.H. `DV = H.nodes(data='color', default='red')`.
+    to create a DataView e.g. `DV = H.nodes.data(data='color', default='red')`.
     The DataView iterates as `for n, color in DV` and allows
-    `(n, 'red') in DV`. Using `DV = H.nodes(data=True)`, the DataViews
+    `(n, 'red') in DV`. Using `DV = H.nodes.data()`, the DataViews
     use the full datadict in writeable form also allowing contain testing as
     `(n, {'color': 'red'}) in VD`. DataViews allow set operations when
     data attributes are hashable.

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -1,5 +1,5 @@
 """
-View Classes provide node, edge and degree "views" of a hypergraph.
+View Classes provide node, edge, degree, and edge size "views" of a hypergraph.
 
 A view means a read-only object that is quick to create, automatically
 updated when the hypergraph changes, and provides basic access like `n in V`,
@@ -10,7 +10,7 @@ hypergraph is updated. As with dicts, the hypergraph should not be updated
 while iterating through the view. Views can be iterated multiple times.
 
 Edge and Node views also allow data attribute lookup.
-The resulting attribute dict is writable as `H.edges[3, 4]['color']='red'`
+The resulting attribute dict is writable as `H.edges[3]['color']='red'`
 Degree views allow lookup of degree values for single nodes.
 Weighted degree is supported with the `weight` argument.
 
@@ -20,17 +20,6 @@ NodeView
     `V = H.nodes` (or `V = H.nodes()`) allows `len(V)`, `n in V`, set
     operations e.H. "H.nodes & H.nodes", and `dd = H.nodes[n]`, where
     `dd` is the node data dict. Iteration is over the nodes by default.
-
-NodeDataView
-============
-
-    To iterate over (node, data) pairs, use arguments to `H.nodes()`
-    to create a DataView e.g. `DV = H.nodes.data(data='color', default='red')`.
-    The DataView iterates as `for n, color in DV` and allows
-    `(n, 'red') in DV`. Using `DV = H.nodes.data()`, the DataViews
-    use the full datadict in writeable form also allowing contain testing as
-    `(n, {'color': 'red'}) in VD`. DataViews allow set operations when
-    data attributes are hashable.
 
 EdgeView
 ========
@@ -42,15 +31,6 @@ EdgeView
     Set operations are currently performed by id, not by set equivalence.
     This may be in future functionality. As it stands, however, the same edge
     can be added more than once using different IDs
-
-EdgeDataView
-============
-
-    Edge data can be reported using an EdgeDataView typically created
-    by calling an EdgeView: `DV = H.edges(data='weight', default=1)`.
-    The EdgeDataView allows iteration over edge ids.
-
-    The argument `nbunch` restricts edges to those incident to nodes in nbunch.
 
 DegreeView
 ==========
@@ -82,81 +62,78 @@ from xgi.exception import XGIError
 
 __all__ = [
     "NodeView",
-    "NodeDataView",
     "EdgeView",
-    "EdgeDataView",
     "DegreeView",
     "EdgeSizeView",
 ]
 
+# ID View Base Class
+class IDView(Mapping, Set):
+    """A Base View class to act as H.nodes and H.edges for a Hypergraph."""
 
-# NodeViews
-class NodeView(Mapping, Set):
-    """A NodeView class to act as H.nodes for a Hypergraph."""
-
-    __slots__ = ("_nodes", "_node_attr")
+    __slots__ = ("_ids", "_id_attrs")
 
     def __getstate__(self):
-        """Function that allows pickling of the nodes (write)
+        """Function that allows pickling of the IDs (write)
 
         Returns
         -------
         dict of dict
-            The keys access the nodes and their attributes respectively
+            The keys access the IDs and their attributes respectively
             and the values are dictionarys from the Hypergraph class.
         """
-        return {"_nodes": self._nodes, "_node_attr": self._node_attr}
+        return {"_ids": self._ids, "_id_attrs": self._id_attrs}
 
     def __setstate__(self, state):
-        """Function that allows pickling of the nodes (read)
+        """Function that allows pickling of the IDs (read)
 
         Parameters
         ----------
         state : dict of dict
-            The keys access the nodes and their attributes respectively
+            The keys access the IDs and their attributes respectively
             and the values are dictionarys from the Hypergraph class.
         """
-        self._nodes = state["_nodes"]
-        self._node_attr = state["_node_attr"]
+        self._ids = state["_ids"]
+        self._id_attrs = state["_id_attrs"]
 
-    def __init__(self, H):
-        """Initialize the NodeView with a hypergraph
-
+    def __init__(self, ids, id_attrs):
+        """Initialize the IDView with IDs and associated attributes
         Parameters
         ----------
-        hypergraph : Hypergraph object
-            The hypergraph of interest
+        ids : dict
+            Specifies IDs and the associated adjacency list
+        id_attrs : dict
+            Specifies IDs and their associated attributes.
         """
-        self._nodes = H._node
-        self._node_attr = H._node_attr
+        self._ids = ids
+        self._id_attrs = id_attrs
 
     # Mapping methods
+    # Mapping methods
     def __len__(self):
-        """Return the number of nodes
-
+        """Return the number of IDs
         Returns
         -------
         int
-            Number of nodes
+            Number of IDs
         """
-        return len(self._nodes)
+        return len(self._ids)
 
     def __iter__(self):
-        """Returns an iterator over the node IDs.
-
+        """Returns an iterator over the IDs.
         Returns
         -------
         iterator of hashables
-            Each entry is a node in the hypergraph.
+            Each entry is an ID in the hypergraph.
         """
-        return iter(self._nodes)
+        return iter(self._ids)
 
-    def __getitem__(self, n):
-        """Get the attributes of the node.
+    def __getitem__(self, id):
+        """Get the attributes of the ID.
 
         Parameters
         ----------
-        n : hashable
+        id : hashable
             node ID
 
         Returns
@@ -171,104 +148,38 @@ class NodeView(Mapping, Set):
             the node does not exist in the hypergraph.
 
         """
-        if isinstance(n, slice):
-            raise XGIError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(H.nodes)[{n.start}:{n.stop}:{n.step}]"
-            )
-        elif n not in self._nodes:
-            raise XGIError(f"The node {n} is not in the hypergraph")
-
-        return self._node_attr[n]
+        try:
+            return self._id_attrs[id]
+        except:
+            if isinstance(id, slice):
+                raise XGIError(
+                    f"{type(self).__name__} does not support slicing, "
+                    f"try list(H.nodes)[{id.start}:{id.stop}:{id.step}]"
+                )
+            elif id not in self._ids:
+                raise XGIError(f"The ID {id} is not in the hypergraph")
 
     # Set methods
-    def __contains__(self, n):
-        """Checks whether the node is in the hypergraph
-
+    def __contains__(self, id):
+        """Checks whether the ID is in the hypergraph
         Parameters
         ----------
-        n : hashable
-            The ID of a node
-
+        id : hashable
+            A unique ID
         Returns
         -------
         bool
-            True if the node is in the hypergraph, False otherwise.
+            True if the ID is in the hypergraph, False otherwise.
         """
-        return n in self._nodes
-
-    def data(self, data=True, default=None):
-        """Return a read-only view of node data.
-
-        Parameters
-        ----------
-        data : bool or node data key, default=True
-            If ``data=True`` (the default), return a `NodeDataView` object that
-            maps each node to *all* of its attributes. `data` may also be an
-            arbitrary key, in which case the `NodeDataView` maps each node to
-            the value for the keyed attribute. In this case, if a node does
-            not have the `data` attribute, the `default` value is used.
-        default : object, default=None
-            The value used when a node does not have a specific attribute.
-
-        Returns
-        -------
-        NodeDataView
-            The layout of the returned NodeDataView depends on the value of the
-            `data` parameter.
-
-        Notes
-        -----
-        If ``data=False``, returns a `NodeView` object without data.
-
-        See Also
-        --------
-        NodeDataView
-
-        Examples
-        --------
-        >>> H = xgi.Hypergraph()
-        >>> H.add_nodes_from([
-        ...     (0, {"color": "red", "weight": 10}),
-        ...     (1, {"color": "blue"}),
-        ...     (2, {"color": "yellow", "weight": 2})
-        ... ])
-
-        Accessing node data with ``data=True`` (the default) returns a
-        NodeDataView mapping each node to all of its attributes:
-
-        >>> H.nodes.data()
-        NodeDataView({0: {'color': 'red', 'weight': 10}, 1: {'color': 'blue'}, 2: {'color': 'yellow', 'weight': 2}})
-
-        If `data` represents  a key in the node attribute dict, a NodeDataView mapping
-        the nodes to the value for that specific key is returned:
-
-        >>> H.nodes.data("color")
-        NodeDataView({0: 'red', 1: 'blue', 2: 'yellow'}, data='color')
-
-        If a specific key is not found in an attribute dict, the value specified
-        by `default` is returned:
-
-        >>> H.nodes.data("weight", default=-999)
-        NodeDataView({0: 10, 1: -999, 2: 2}, data='weight')
-
-        Note that there is no check that the `data` key is in any of the
-        node attribute dictionaries:
-
-        >>> H.nodes.data("height")
-        NodeDataView({0: None, 1: None, 2: None}, data='height')
-        """
-        if data is False:
-            return self
-        return NodeDataView(self._node_attr, data, default)
+        return id in self._ids
 
     def __str__(self):
-        """Returns a string of the list of node IDs.
+        """Returns a string of the list of IDs.
 
         Returns
         -------
         string
-            A string of the list of node IDs.
+            the list of IDs.
         """
         return str(list(self))
 
@@ -278,336 +189,16 @@ class NodeView(Mapping, Set):
         Returns
         -------
         string
-            The class name with the node IDs.
+            The class name with the IDs.
         """
         return f"{self.__class__.__name__}({tuple(self)})"
 
-    def members(self, n):
-        """Handles calling the nodes, i.e. H.nodes(n).
-
-        Identical to __getitem__, __call__
+    def members(self, id):
+        """Get the bipartite neighbors of an ID.
 
         Parameters
         ----------
-        n : hashable
-            node ID
-
-        Returns
-        -------
-        list
-            A list of the edge IDs of which the node is a part.
-
-        Raises
-        ------
-        xgi.XGIError
-            Returns an error if the user tries passing in a slice or if
-            the node does not exist in the hypergraph.
-
-        See Also
-        --------
-        __getitem__
-        """
-        if isinstance(n, slice):
-            raise XGIError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(H.nodes)[{n.start}:{n.stop}:{n.step}]"
-            )
-        elif n not in self._nodes:
-            raise XGIError(f"The node {n} is not in the hypergraph")
-        return self._nodes[n]
-
-    membership = members
-
-
-
-class NodeDataView(Set):
-    """A DataView class for nodes of a Hypergraph
-
-    The main use for this class is to iterate through node-data pairs.
-    The data can be the entire data-dictionary for each node, or it
-    can be a specific attribute (with default) for each node.
-    Set operations are enabled with NodeDataView, but don't work in
-    cases where the data is not hashable. Use with caution.
-    Typically, set operations on nodes use NodeView, not NodeDataView.
-    That is, they use `H.nodes` instead of `H.nodes(data='foo')`.
-    """
-
-    __slots__ = ("_node_attr", "_data", "_default")
-
-    def __getstate__(self):
-        """Function that allows pickling of the node data (write)
-
-        Returns
-        -------
-        dict of dict
-            The keys access the node attributes, the data key, and the default value respectively
-            and the values are a dictionary, a hashable, and a hashable respectively.
-        """
-        return {
-            "_node_attr": self._node_attr,
-            "_data": self._data,
-            "_default": self._default,
-        }
-
-    def __setstate__(self, state):
-        """Function that allows pickling of the node data (read)
-
-        Parameters
-        ----------
-        state : dict of dict
-            The keys access the node attributes, the data key, and the default value respectively
-            and the values are a dictionary, a hashable, and a hashable respectively.
-        """
-        self._node_attr = state["_node_attr"]
-        self._data = state["_data"]
-        self._default = state["_default"]
-
-    def __init__(self, node_attr, data=True, default=None):
-        """Initialize the NodeDataView object
-
-        Parameters
-        ----------
-        node_attr : dict
-            The dictionary of attributes with node IDs as keys
-            and dictionaries as values
-        data : bool or hashable, optional
-            Whether or not to return all the data
-            or the key for the attribute, by default True
-        default : anything, optional
-            The value that should be returned if
-            the key value doesn't exist, by default None
-        """
-        self._node_attr = node_attr
-        self._data = data
-        self._default = default
-
-    def __len__(self):
-        """Returns the number of nodes
-
-        Returns
-        -------
-        int
-            Number of nodes
-        """
-        return len(self._node_attr)
-
-    def __iter__(self):
-        """Returns an iterator over node IDs
-        or node ID, value pairs if the data
-        keyword arg is not False.
-
-        Returns
-        -------
-        iterator
-            Iterator over node IDs (data=False) or node ID, value
-            pairs (else).
-        """
-        data = self._data
-        if data is False:
-            return iter(self._node_attr)
-        if data is True:
-            return iter(self._node_attr.items())
-        return (
-            (n, dd[data] if data in dd else self._default)
-            for n, dd in self._node_attr.items()
-        )
-
-    def __contains__(self, n):
-        """Checks whether a node ID are in a
-        hypergraph.
-
-        Parameters
-        ----------
-        n : hashable
-            node ID
-
-        Returns
-        -------
-        bool
-            Whether the node is the hypergraph.
-        """
-        return n in self._node_attr
-
-    def __getitem__(self, n):
-        """Get the data from a node.
-
-        Parameters
-        ----------
-        n : hashable
-            Node ID
-
-        Returns
-        -------
-        dict
-            empty dictionary if False, data dictionary if True,
-            and a dictionary with one key if the key is specified.
-
-        Raises
-        ------
-        xgi.XGIError
-            Returns an error if the user tries passing in a slice or if
-            the node does not exist in the hypergraph.
-        """
-        if isinstance(n, slice):
-            raise XGIError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(H.nodes.data())[{n.start}:{n.stop}:{n.step}]"
-            )
-        elif n not in self._data:
-            raise XGIError(f"The node {n} is not in the hypergraph")
-
-        ddict = self._node_attr[n]
-        data = self._data
-        if data is False:
-            return dict()
-        elif data is True:
-            return ddict
-        return {data: ddict[data]} if data in ddict else {data: self._default}
-
-    def __str__(self):
-        """Returns a string listing the node IDs.
-
-        Returns
-        -------
-        string
-            A string listing the node IDs.
-        """
-        return str(list(self))
-
-    def __repr__(self):
-        """Controls what is displayed when calling repr(H.nodes.data)
-
-        Returns
-        -------
-        string
-            A string with the class name, nodes, and data.
-        """
-        name = self.__class__.__name__
-        if self._data is False:
-            return f"{name}({tuple(self)})"
-        if self._data is True:
-            return f"{name}({dict(self)})"
-        return f"{name}({dict(self)}, data={self._data!r})"
-
-
-# EdgeViews have set operations and no data reported
-class EdgeView(Set, Mapping):
-    """A EdgeView class for the edges of a Hypergraph"""
-
-    __slots__ = ("_edges", "_edge_attr")
-
-    def __getstate__(self):
-        """Function that allows pickling of the edges (write)
-
-        Returns
-        -------
-        dict of dict
-            The keys access the edges and the value is
-            a dictionary of the hypergraph "_edge" dictionary.
-        """
-        return {"_edges": self._edges, "_edge_attr": self._edge_attr}
-
-
-    def __setstate__(self, state):
-        """Function that allows pickling of the edges (read)
-
-        Parameters
-        ----------
-        state : dict of dict
-            The keys access the edges and the value is
-            a dictionary of the hypergraph "_edge" dictionary.
-        """
-        self._edges = state["_edges"]
-        self._edge_attr = state["_edge_attr"]
-
-    def __init__(self, H):
-        """Initialize the EdgeView object
-
-        Parameters
-        ----------
-        H : Hypergraph object
-            The hypergraph of interest.
-        """
-        self._edges = H._edge
-        self._edge_attr = H._edge_attr
-
-    # Set methods
-    def __len__(self):
-        """Get the number of edges
-
-        Returns
-        -------
-        int
-            The number of edges
-        """
-        return len(self._edges)
-
-    def __iter__(self):
-        """Returns an iterator over edge IDs.
-
-        Returns
-        -------
-        iterator
-            Iterator over the edge IDs.
-        """
-        return iter(self._edges)
-
-    def __contains__(self, e):
-        """Return edge members if the edge ID is
-        in the hypergraph and False if not.
-
-        Parameters
-        ----------
-        e : hashable
-            the edge ID
-
-        Returns
-        -------
-        bool or list
-            Returns False if the edge ID does not exist in
-            the hypergraph and the edge as a list if it does.
-        """
-        try:
-            return self._edges[e]
-        except KeyError:
-            return False
-
-    def __getitem__(self, e):
-        """Get the attributes of an edge.
-
-        Parameters
-        ----------
-        e : hashable
-            edge ID
-
-        Returns
-        -------
-        dict
-            Edge attributes
-
-        Raises
-        ------
-        xgi.XGIError
-            Returns an error if the user tries passing in a slice or if
-            the edge ID does not exist in the hypergraph.
-
-        """
-        if isinstance(e, slice):
-            raise XGIError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(H.edges)[{e.start}:{e.stop}:{e.step}]"
-            )
-        elif e not in self._edges:
-            raise XGIError(f"The edge {e} is not in the hypergraph")
-        return self._edge_attr[e]
-
-    def members(self, e):
-        """Get the members of an edge as a list
-        given an edge ID.
-
-        Parameters
-        ----------
-        e : hashable
+        id : hashable
             edge ID
 
         Returns
@@ -620,496 +211,157 @@ class EdgeView(Set, Mapping):
         xgi.XGIError
             Returns an error if the user tries passing in a slice or if
             the edge ID does not exist in the hypergraph.
-
-        See Also
-        --------
-        __getitem__
-        __call__
         """
-        if isinstance(e, slice):
-            raise XGIError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(H.edges)[{e.start}:{e.stop}:{e.step}]"
-            )
-        elif e not in self._edges:
-            raise XGIError(f"The edge {e} is not in the hypergraph")
-        return self._edges[e]
+        try:
+            return self._ids[id]
+        except:
+            if isinstance(id, slice):
+                raise XGIError(
+                    f"{type(self).__name__} does not support slicing, "
+                    f"try (for example) list(H.edges)[{id.start}:{id.stop}:{id.step}]"
+                )
+            elif id not in self._ids:
+                raise XGIError(f"The ID {id} is not in the hypergraph")
 
-    def data(self, data=True, default=None, nbunch=None):
-        """Return the data associated with edges
-
-        Parameters
-        ----------
-        data : bool, optional
-            True for all associated data, False for no data,
-            and a hashable specifying the attribute desired,
-            by default True
-        default : anything, optional
-            The value to return if the attribute doesn't exist,
-            by default None
-        nbunch : iterable, optional
-            A list of edge IDs, by default None
-
-        Returns
-        -------
-        EdgeDataView object
-            The edges of the hypergraph.
-        """
-        if nbunch is None and data is False:
-            return self
-        return EdgeDataView(self, nbunch, data, default)
-
-    # String Methods
-    def __str__(self):
-        """Return a string of edge IDs
-
-        Returns
-        -------
-        string
-            A string of edge IDs
-        """
-        return str(list(self))
-
-    def __repr__(self):
-        """Returns a string representing the EdgeView.
-
-        Returns
-        -------
-        string
-            Returns a string stating the class name
-            and the edge IDs in the class
-        """
-        return f"{self.__class__.__name__}({list(self)})"
+    membership = members
 
 
-# EdgeDataViews
-class EdgeDataView:
-    """EdgeDataView for edges of Hypergraph"""
-
-    __slots__ = ("_edge_attr", "_data", "_default")
-
-    def __getstate__(self):
-        """Function that allows pickling of the edge data (write)
-
-        Returns
-        -------
-        dict of dict
-            The keys access the edge attributes, the data key, and the default value respectively
-            and the values are a dictionary, a hashable, and a hashable respectively.
-        """
-        self._n
-        return {
-            "_edge_attr": self._edge_attr,
-            "_data": self._data,
-            "_default": self._default,
-        }
-
-    def __setstate__(self, state):
-        """Function that allows pickling of the edge data (read)
-
-        Parameters
-        ----------
-        state : dict of dict
-            The keys access the edge attributes, the data key, and the default value respectively
-            and the values are a dictionary, a hashable, and a hashable respectively.
-        """
-        self._edge_attr = state["_edge_attr"]
-        self._data = state["_data"]
-        self._default = state["_default"]
-
-    def __init__(self, edgedict, data=True, default=None):
-        """Initialize the edge data object with the hypergraph data.
-
-        Parameters
-        ----------
-        edgedict : dict
-            The edge attribute dictionary
-        data : bool or hashable, optional
-            True for all associated data, False for no data,
-            and a hashable specifying the attribute desired,
-            by default True
-        default : anything, optional
-            The value to return if the attribute doesn't exist,
-            by default None
-        """
-        self._edge_attr = edgedict
-        self._data = data
-        self._default = default
-
-    def __len__(self):
-        """Get the number of edges
-
-        Returns
-        -------
-        int
-            The number of edges
-        """
-        return len(self._edge_attr)
-
-    def __iter__(self):
-        """Returns an iterator over edge IDs
-        or edge ID, value pairs if the data
-        keyword arg is not False.
-
-        Returns
-        -------
-        iterator
-            Iterator over edge IDs (data=False) or edge ID, value
-            pairs (else).
-        """
-        data = self._data
-        if data is False:
-            return iter(self._edge_attr)
-        if data is True:
-            return iter(self._edge_attr.items())
-        return (
-            (e, dd[data] if data in dd else self._default)
-            for e, dd in self._edge_attr.items()
-        )
-
-    def __contains__(self, e):
-        """Returns whether an edge ID is in the hypergraph
-
-        Parameters
-        ----------
-        n : hashable
-            edge ID
-
-        Returns
-        -------
-        bool
-            True if the edge ID is in the hypergraph, False if note.
-        """
-        return e in self._edge_attr
-
-    def __getitem__(self, e):
-        """Get the data from an edge.
-
-        Parameters
-        ----------
-        e : hashable
-            edge ID
-
-        Returns
-        -------
-        dict
-            empty dictionary if False, data dictionary if True,
-            and a dictionary with one key if the key is specified.
-
-        Raises
-        ------
-        xgi.XGIError
-            Returns an error if the user tries passing in a slice or if
-            the edge ID does not exist in the hypergraph.
-        """
-        if isinstance(e, slice):
-            raise XGIError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(H.nodes.data())[{e.start}:{e.stop}:{e.step}]"
-            )
-        elif e not in self._edge_attr:
-            raise XGIError(f"The edge ID {e} is not in the hypergraph")
-
-        ddict = self._edge_attr[e]
-        data = self._data
-        if data is False:
-            return dict()
-        elif data is True:
-            return ddict
-        return {data: ddict[data]} if data in ddict else {data: self._default}
-
-    def __str__(self):
-        """Return a string of the edge IDs
-
-        Returns
-        -------
-        string
-            A string of the edge IDs
-        """
-        return str(list(self))
-
-    def __repr__(self):
-        """Returns a string representation of the edge data.
-
-        Returns
-        -------
-        string
-            A string representation of the EdgeDataView
-            with the class name, edge IDs, and associated data.
-        """
-        name = self.__class__.__name__
-        if self._data is False:
-            return f"{name}({tuple(self)})"
-        if self._data is True:
-            return f"{name}({dict(self)})"
-        return f"{name}({dict(self)}, data={self._data!r})"
-
-
-# DegreeViews
-class DegreeView:
-    """A View class for the degree of nodes in a Hypergraph
-
-    The functionality is like dict.items() with (node, degree) pairs.
-    Additional functionality includes read-only lookup of node degree,
-    and calling with optional features nbunch (for only a subset of nodes)
-    and weight (use edge weights to compute degree).
-
+# ID Degree View Base Class
+class IDDegreeView:
+    """A View class for the degree of IDs in a Hypergraph
+    The functionality is like dict.items() with (ID, degree) pairs.
+    Additional functionality includes read-only lookup of degree,
+    and calling with optional features nbunch (for only a subset of IDs)
+    and weight (use weights to compute degree).
     Notes
     -----
-    DegreeView can still lookup any node even if nbunch is specified.
+    IDDegreeView can still lookup any ID even if nbunch is specified.
     """
 
-    __slots__ = ("_hypergraph", "_nodes", "_edges", "_edge_attr", "_weight")
+    __slots__ = ("_ids", "_id_attrs", "_weight")
 
-    def __init__(self, H, nbunch=None, weight=None):
+    def __init__(self, ids, id_attrs, id_bunch=None, weight=None):
         """Initialize the DegreeView object
-
         Parameters
         ----------
-        H : Hypergraph object
-            The hypergraph of interest
-        nbunch : node, container of nodes, or None meaning all nodes (default=None)
-            The nodes for which to find the degree
-        weight : hashable or bool, optional
-            The name of the attribute to weight the degree, by default None
+        ids : dict
+            A dictionary with IDs as keys and a list of bipartite relations
+            as values
+        id_attrs : dict
+            A dictionary with IDs as keys and a dictionary of properties as values.
+            Used to weight the degree.
+        nbunch : ID, container of IDs, or None meaning all IDs (default=None)
+            The IDs for which to find the degree
+        weight : hashable, optional
+            The name of the attribute to weight the degree, by default None.
         """
-        self._hypergraph = H
-        self._nodes = (
-            H.nodes
-            if nbunch is None
-            else {id: val for id, val in H.nodes.items() if id in nbunch}
+        self._ids = (ids
+            if id_bunch is None
+            else {id: val for id, val in ids.items() if id in id_bunch}
         )
-        self._edges = H.edges
-        self._edge_attr = H._edge_attr
+        self._id_attrs = id_attrs
         self._weight = weight
 
-    def __call__(self, nbunch=None, weight=None):
-        """Get the degree of specified nodes
-
+    def __call__(self, id_bunch=None, weight=None):
+        """Get the degree of specified IDs
         Parameters
         ----------
-        nbunch : node, container of nodes, or None, optional
-            The nodes for which to find the degree, by default None
-        weight : [type], optional
-            [description], by default None
-
+        nbunch : ID, container of IDs, or None, optional
+            The IDs for which to find the degree, by default None
+        weight : hashable, optional
+            The name of the attribute to weight the degree, by default None
         Returns
         -------
         DegreeView
             The degrees of the hypergraph
         """
-        if nbunch is None:
+        if id_bunch is None:
             if weight == self._weight:
                 return self
-            return self.__class__(self._hypergraph, None, weight)
+            return self.__class__(self._ids, self._id_attrs, None, weight)
         try:
-            if nbunch in self._nodes:
+            if id_bunch in self._ids:
                 if weight == self._weight:
-                    return self[nbunch]
-                return self.__class__(self._hypergraph, None, weight)[nbunch]
+                    return self[id_bunch]
+                return self.__class__(self._ids, self._id_attrs, None, weight)[id_bunch]
         except TypeError:
             pass
-        return self.__class__(self._hypergraph, nbunch, weight)
+        return self.__class__(self._ids, self._id_attrs, id_bunch, weight)
 
-    def __getitem__(self, n):
-        """Get the degree of a node
-
+    def __getitem__(self, id):
+        """Get the degree for an ID
         Parameters
         ----------
-        n : hashable
-            node ID
-
+        id : hashable
+            Unique ID
         Returns
         -------
         float
-            The degree of a node, weighted or unweighted
+            The degree of an ID, weighted or unweighted
         """
         weight = self._weight
         if weight is None:
-            return len(self._nodes(n))
-        return sum(self._edge_attr[dd].get(weight, 1) for dd in self._nodes(n))
+            return len(self._ids(id))
+        return sum(self._id_attrs[dd].get(weight, 1) for dd in self._ids(id))
 
     def __iter__(self):
-        """Returns an iterator of node ID, node degree pairs.
-
+        """Returns an iterator of ID, degree pairs.
         Yields
         -------
         iterator of tuples
-            Each entry is a node ID, degree (Weighted or unweighted) pair.
+            Each entry is an ID, degree (Weighted or unweighted) pair.
         """
         weight = self._weight
         if weight is None:
-            for n in self._nodes:
-                yield (n, len(self._nodes.members(n)))
+            for n in self._ids:
+                yield (n, len(self._ids[n]))
         else:
-            for n in self._nodes:
-                elements = self._nodes(n)
-                deg = sum(self._edge_attr[dd].get(weight, 1) for dd in elements)
+            for n in self._ids:
+                elements = self._ids(n)
+                deg = sum(self._id_attrs[dd].get(weight, 1) for dd in elements)
                 yield (n, deg)
 
     def __len__(self):
-        """Returns the number of nodes/degrees
-
+        """Returns the number of IDs/degrees
         Returns
         -------
         int
-            Number of nodes/degrees
+            Number of IDs/degrees
         """
-        return len(self._nodes)
+        return len(self._ids)
 
     def __str__(self):
-        """Returns a string of node IDs.
-
+        """Returns a string of IDs.
         Returns
         -------
         string
-            A string of the list of node IDs.
+            A string of the list of IDs.
         """
-        return str(list(self._nodes))
+        return str(list(self._ids))
 
     def __repr__(self):
         """A string representation of the degrees
-
         Returns
         -------
         string
-            A string representation of the DegreeView
+            A string representation of the IDDegreeView
             with the class name and a dictionary of
-            the node ID, degree pairs
+            the ID, degree pairs
         """
         return f"{self.__class__.__name__}({dict(self)})"
 
+class NodeView(IDView):
+    def __init__(self, hypergraph):
+        super(NodeView, self).__init__(hypergraph._node, hypergraph._node_attr)
 
-class EdgeSizeView:
-    """A View class for the size of edges in a Hypergraph
+class EdgeView(IDView):
+    def __init__(self, hypergraph):
+        super(EdgeView, self).__init__(hypergraph._edge, hypergraph._edge_attr)
 
-    The functionality is like dict.items() with (edge, size) pairs.
-    Additional functionality includes read-only lookup of edge size,
-    and calling with optional features nbunch (for only a subset of edges)
-    and weight (use node weights to compute a weighted size).
+class DegreeView(IDDegreeView):
+    def __init__(self, hypergraph, nbunch=None, weight=None):
+        super().__init__(hypergraph._node, hypergraph._edge_attr, id_bunch=nbunch, weight=weight)
 
-    Notes
-    -----
-    EdgeSizeView can still lookup any node even if nbunch is specified.
-    """
-
-    __slots__ = ("_hypergraph", "_edges", "_nodes", "_node_attr", "_weight")
-
-    def __init__(self, H, nbunch=None, weight=None):
-        """Initialize
-
-        Parameters
-        ----------
-        H : Hypergraph object
-            The hypergraph of interest
-        nbunch : node, container of nodes, or None meaning all nodes (default=None)
-            The edges for which to find the size, by default None
-        weight : bool or string, optional
-            Weight attribute, by default None
-        """
-        self._hypergraph = H
-        self._edges = (
-            H.edges
-            if nbunch is None
-            else {id: val for id, val in H.edges.items() if id in nbunch}
-        )
-        self._nodes = H.nodes
-        self._node_attr = H._node_attr
-        self._weight = weight
-
-    def __call__(self, nbunch=None, weight=None):
-        """Get the degree of specified nodes
-
-        Parameters
-        ----------
-        nbunch : edge, container of edges, or None, optional
-            The edges for which to find the size, by default None
-        weight : hanshable or bool, optional
-            The weight attribute of the nodes, by default None
-
-        Returns
-        -------
-        EdgeSizeView
-            The edge sizes of the hypergraph
-        """
-        if nbunch is None:
-            if weight == self._weight:
-                return self
-            return self.__class__(self._hypergraph, None, weight)
-        try:
-            if nbunch in self._edges:
-                if weight == self._weight:
-                    return self[nbunch]
-                return self.__class__(self._hypergraph, None, weight)[nbunch]
-        except TypeError:
-            pass
-        return self.__class__(self._hypergraph, nbunch, weight)
-
-    def __getitem__(self, e):
-        """Get the degree of specified nodes
-
-        Parameters
-        ----------
-        e : hashable
-            The edge id for which to find the size
-
-        Returns
-        -------
-        float
-            The edge size (weighted or uunweighted)
-        """
-        weight = self._weight
-        if weight is None:
-            return len(self._edges(e))
-        return sum(self._node_attr[dd].get(weight, 1) for dd in self._edges(e))
-
-    def __iter__(self):
-        """Returns an iterator over edge ID, edge size pairs.
-
-        Yields
-        -------
-        iterator of tuples
-            Each entry is an edge ID, edge size
-            (weighted or unweighted) pairs.
-        """
-        weight = self._weight
-        if weight is None:
-            for e in self._edges:
-                yield (e, len(self._edges.members(e)))
-        else:
-            for e in self._edges:
-                elements = self._edges(e)
-                deg = sum(self._node_attr[dd].get(weight, 1) for dd in elements)
-                yield (e, deg)
-
-    def __len__(self):
-        """Returns the number of edges/edge sizes
-
-        Returns
-        -------
-        int
-            The number of edges/edge sizes
-        """
-        return len(self._edges)
-
-    def __str__(self):
-        """Returns a string of the edge IDs.
-
-        Returns
-        -------
-        string
-            A string of the list of edge IDs.
-        """
-        return str(list(self._edges))
-
-    def __repr__(self):
-        """A string representation of the EdgeSizeView class.
-
-        Returns
-        -------
-        string
-            A string representing the EdgeSizeSize class with the
-            class name and a dictionary with edge IDs as keys and
-            edge sizes as values.
-        """
-        return f"{self.__class__.__name__}({dict(self)})"
+class EdgeSizeView(IDDegreeView):
+    def __init__(self, hypergraph, ebunch=None, weight=None):
+        super().__init__(hypergraph._edge, hypergraph._node_attr, id_bunch=ebunch, weight=weight)

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -193,38 +193,6 @@ class IDView(Mapping, Set):
         """
         return f"{self.__class__.__name__}({tuple(self)})"
 
-    def members(self, id):
-        """Get the bipartite neighbors of an ID.
-
-        Parameters
-        ----------
-        id : hashable
-            edge ID
-
-        Returns
-        -------
-        list
-            edge members
-
-        Raises
-        ------
-        xgi.XGIError
-            Returns an error if the user tries passing in a slice or if
-            the edge ID does not exist in the hypergraph.
-        """
-        try:
-            return self._ids[id]
-        except:
-            if isinstance(id, slice):
-                raise XGIError(
-                    f"{type(self).__name__} does not support slicing, "
-                    f"try (for example) list(H.edges)[{id.start}:{id.stop}:{id.step}]"
-                )
-            elif id not in self._ids:
-                raise XGIError(f"The ID {id} is not in the hypergraph")
-
-    memberships = members
-
 
 # ID Degree View Base Class
 class IDDegreeView:
@@ -355,12 +323,71 @@ class IDDegreeView:
 class NodeView(IDView):
     def __init__(self, hypergraph):
         super(NodeView, self).__init__(hypergraph._node, hypergraph._node_attr)
+    
+    def memberships(self, id):
+        """Get the bipartite neighbors of an ID.
+
+        Parameters
+        ----------
+        id : hashable
+            edge ID
+
+        Returns
+        -------
+        list
+            edge members
+
+        Raises
+        ------
+        xgi.XGIError
+            Returns an error if the user tries passing in a slice or if
+            the edge ID does not exist in the hypergraph.
+        """
+        try:
+            return self._ids[id]
+        except:
+            if isinstance(id, slice):
+                raise XGIError(
+                    f"{type(self).__name__} does not support slicing, "
+                    f"try (for example) list(H.edges)[{id.start}:{id.stop}:{id.step}]"
+                )
+            elif id not in self._ids:
+                raise XGIError(f"The ID {id} is not in the hypergraph")
 
 
 class EdgeView(IDView):
     def __init__(self, hypergraph):
         super(EdgeView, self).__init__(hypergraph._edge, hypergraph._edge_attr)
+    
+    def members(self, id):
+        """Get the bipartite neighbors of an ID.
 
+        Parameters
+        ----------
+        id : hashable
+            edge ID
+
+        Returns
+        -------
+        list
+            edge members
+
+        Raises
+        ------
+        xgi.XGIError
+            Returns an error if the user tries passing in a slice or if
+            the edge ID does not exist in the hypergraph.
+        """
+        try:
+            return self._ids[id]
+        except:
+            if isinstance(id, slice):
+                raise XGIError(
+                    f"{type(self).__name__} does not support slicing, "
+                    f"try (for example) list(H.edges)[{id.start}:{id.stop}:{id.step}]"
+                )
+            elif id not in self._ids:
+                raise XGIError(f"The ID {id} is not in the hypergraph")
 
 class DegreeView(IDDegreeView):
     def __init__(self, hypergraph, nbunch=None, weight=None):

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -150,7 +150,7 @@ class IDView(Mapping, Set):
         """
         try:
             return self._id_attrs[id]
-        except:
+        except KeyError:
             if isinstance(id, slice):
                 raise XGIError(
                     f"{type(self).__name__} does not support slicing, "
@@ -345,7 +345,7 @@ class NodeView(IDView):
         """
         try:
             return self._ids[id]
-        except:
+        except KeyError:
             if isinstance(id, slice):
                 raise XGIError(
                     f"{type(self).__name__} does not support slicing, "
@@ -380,7 +380,7 @@ class EdgeView(IDView):
         """
         try:
             return self._ids[id]
-        except:
+        except KeyError:
             if isinstance(id, slice):
                 raise XGIError(
                     f"{type(self).__name__} does not support slicing, "

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -321,16 +321,23 @@ class IDDegreeView:
 
 
 class NodeView(IDView):
+    """ Class for representing the nodes.
+
+    Much of the functionality in this class inherits from IDView
+    """
     def __init__(self, hypergraph):
         super(NodeView, self).__init__(hypergraph._node, hypergraph._node_attr)
     
-    def memberships(self, id):
-        """Get the bipartite neighbors of an ID.
+    def memberships(self, n):
+        """Get the edges of which a node is a member.
+
+        Given a node ID, this method returns the edge IDs
+        of which this node is a member.
 
         Parameters
         ----------
-        id : hashable
-            edge ID
+        n : hashable
+            node ID
 
         Returns
         -------
@@ -341,30 +348,37 @@ class NodeView(IDView):
         ------
         xgi.XGIError
             Returns an error if the user tries passing in a slice or if
-            the edge ID does not exist in the hypergraph.
+            the node ID does not exist in the hypergraph.
         """
         try:
-            return self._ids[id]
+            return self._ids[n]
         except KeyError:
-            if isinstance(id, slice):
+            if isinstance(n, slice):
                 raise XGIError(
                     f"{type(self).__name__} does not support slicing, "
-                    f"try (for example) list(H.edges)[{id.start}:{id.stop}:{id.step}]"
+                    f"try list(H.nodes)[{n.start}:{n.stop}:{n.step}]"
                 )
-            elif id not in self._ids:
-                raise XGIError(f"The ID {id} is not in the hypergraph")
+            elif n not in self._ids:
+                raise XGIError(f"The node ID {n} is not in the hypergraph")
 
 
 class EdgeView(IDView):
+    """ Class for representing the edges.
+
+    Much of the functionality in this class inherits from IDView
+    """
     def __init__(self, hypergraph):
         super(EdgeView, self).__init__(hypergraph._edge, hypergraph._edge_attr)
     
-    def members(self, id):
-        """Get the bipartite neighbors of an ID.
+    def members(self, e):
+        """Get the nodes that are members of an edge.
+        
+        Given an edge ID, this method returns the node IDs
+        that are members of this edge.
 
         Parameters
         ----------
-        id : hashable
+        e : hashable
             edge ID
 
         Returns
@@ -379,17 +393,21 @@ class EdgeView(IDView):
             the edge ID does not exist in the hypergraph.
         """
         try:
-            return self._ids[id]
+            return self._ids[e]
         except KeyError:
-            if isinstance(id, slice):
+            if isinstance(e, slice):
                 raise XGIError(
                     f"{type(self).__name__} does not support slicing, "
-                    f"try (for example) list(H.edges)[{id.start}:{id.stop}:{id.step}]"
+                    f"try list(H.edges)[{e.start}:{e.stop}:{e.step}]"
                 )
-            elif id not in self._ids:
-                raise XGIError(f"The ID {id} is not in the hypergraph")
+            elif e not in self._ids:
+                raise XGIError(f"The edge ID {e} is not in the hypergraph")
 
 class DegreeView(IDDegreeView):
+    """ Class for representing the degrees.
+
+    This class inherits all its functionality from IDDegreeView
+    """
     def __init__(self, hypergraph, nbunch=None, weight=None):
         super().__init__(
             hypergraph._node, hypergraph._edge_attr, id_bunch=nbunch, weight=weight
@@ -397,6 +415,10 @@ class DegreeView(IDDegreeView):
 
 
 class EdgeSizeView(IDDegreeView):
+    """ Class for representing the edge sizes.
+
+    This class inherits all its functionality from IDDegreeView
+    """
     def __init__(self, hypergraph, ebunch=None, weight=None):
         super().__init__(
             hypergraph._edge, hypergraph._node_attr, id_bunch=ebunch, weight=weight

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -94,7 +94,7 @@ __all__ = [
 class NodeView(Mapping, Set):
     """A NodeView class to act as H.nodes for a Hypergraph."""
 
-    __slots__ = ("_nodes", "_node_attrs")
+    __slots__ = ("_nodes", "_node_attr")
 
     def __getstate__(self):
         """Function that allows pickling of the nodes (write)
@@ -105,7 +105,7 @@ class NodeView(Mapping, Set):
             The keys access the nodes and their attributes respectively
             and the values are dictionarys from the Hypergraph class.
         """
-        return {"_nodes": self._nodes, "_node_attrs": self._node_attrs}
+        return {"_nodes": self._nodes, "_node_attr": self._node_attr}
 
     def __setstate__(self, state):
         """Function that allows pickling of the nodes (read)
@@ -117,9 +117,9 @@ class NodeView(Mapping, Set):
             and the values are dictionarys from the Hypergraph class.
         """
         self._nodes = state["_nodes"]
-        self._node_attrs = state["_node_attrs"]
+        self._node_attr = state["_node_attr"]
 
-    def __init__(self, hypergraph):
+    def __init__(self, H):
         """Initialize the NodeView with a hypergraph
 
         Parameters
@@ -127,8 +127,8 @@ class NodeView(Mapping, Set):
         hypergraph : Hypergraph object
             The hypergraph of interest
         """
-        self._nodes = hypergraph._node
-        self._node_attrs = hypergraph._node_attr
+        self._nodes = H._node
+        self._node_attr = H._node_attr
 
     # Mapping methods
     def __len__(self):
@@ -302,7 +302,7 @@ class NodeView(Mapping, Set):
         """
         if data is False:
             return self
-        return NodeDataView(self._node_attrs, data, default)
+        return NodeDataView(self._node_attr, data, default)
 
     def __str__(self):
         """Returns a string of the list of node IDs.
@@ -371,7 +371,7 @@ class NodeDataView(Set):
     That is, they use `H.nodes` instead of `H.nodes(data='foo')`.
     """
 
-    __slots__ = ("_node_attrs", "_data", "_default")
+    __slots__ = ("_node_attr", "_data", "_default")
 
     def __getstate__(self):
         """Function that allows pickling of the node data (write)
@@ -383,7 +383,7 @@ class NodeDataView(Set):
             and the values are a dictionary, a hashable, and a hashable respectively.
         """
         return {
-            "_node_attrs": self._node_attrs,
+            "_node_attr": self._node_attr,
             "_data": self._data,
             "_default": self._default,
         }
@@ -397,16 +397,16 @@ class NodeDataView(Set):
             The keys access the node attributes, the data key, and the default value respectively
             and the values are a dictionary, a hashable, and a hashable respectively.
         """
-        self._node_attrs = state["_node_attrs"]
+        self._node_attr = state["_node_attr"]
         self._data = state["_data"]
         self._default = state["_default"]
 
-    def __init__(self, node_attrs, data=True, default=None):
+    def __init__(self, node_attr, data=True, default=None):
         """Initialize the NodeDataView object
 
         Parameters
         ----------
-        node_attrs : dict
+        node_attr : dict
             The dictionary of attributes with node IDs as keys
             and dictionaries as values
         data : bool or hashable, optional
@@ -416,7 +416,7 @@ class NodeDataView(Set):
             The value that should be returned if
             the key value doesn't exist, by default None
         """
-        self._node_attrs = node_attrs
+        self._node_attr = node_attr
         self._data = data
         self._default = default
 
@@ -428,7 +428,7 @@ class NodeDataView(Set):
         int
             Number of nodes
         """
-        return len(self._node_attrs)
+        return len(self._node_attr)
 
     def __iter__(self):
         """Returns an iterator over node IDs
@@ -443,12 +443,12 @@ class NodeDataView(Set):
         """
         data = self._data
         if data is False:
-            return iter(self._node_attrs)
+            return iter(self._node_attr)
         if data is True:
-            return iter(self._node_attrs.items())
+            return iter(self._node_attr.items())
         return (
             (n, dd[data] if data in dd else self._default)
-            for n, dd in self._node_attrs.items()
+            for n, dd in self._node_attr.items()
         )
 
     def __contains__(self, n):
@@ -465,7 +465,7 @@ class NodeDataView(Set):
         bool
             Whether the node is the hypergraph.
         """
-        return n in self._node_attrs
+        return n in self._node_attr
 
     def __getitem__(self, n):
         """Get the data from a node.
@@ -495,7 +495,7 @@ class NodeDataView(Set):
         elif n not in self._data:
             raise XGIError(f"The node {n} is not in the hypergraph")
 
-        ddict = self._node_attrs[n]
+        ddict = self._node_attr[n]
         data = self._data
         if data is False:
             return dict()
@@ -533,7 +533,7 @@ class NodeDataView(Set):
 class EdgeView(Set, Mapping):
     """A EdgeView class for the edges of a Hypergraph"""
 
-    __slots__ = "_edges"
+    __slots__ = ("_edges", "_edge_attr")
 
     def __getstate__(self):
         """Function that allows pickling of the edges (write)
@@ -544,7 +544,8 @@ class EdgeView(Set, Mapping):
             The keys access the edges and the value is
             a dictionary of the hypergraph "_edge" dictionary.
         """
-        return {"_edges": self._edges}
+        return {"_edges": self._edges, "_edge_attr": self._edge_attr}
+
 
     def __setstate__(self, state):
         """Function that allows pickling of the edges (read)
@@ -556,6 +557,7 @@ class EdgeView(Set, Mapping):
             a dictionary of the hypergraph "_edge" dictionary.
         """
         self._edges = state["_edges"]
+        self._edge_attr = state["_edge_attr"]
 
     def __init__(self, H):
         """Initialize the EdgeView object
@@ -566,6 +568,7 @@ class EdgeView(Set, Mapping):
             The hypergraph of interest.
         """
         self._edges = H._edge
+        self._edge_attr = H._edge_attr
 
     # Set methods
     def __len__(self):
@@ -763,7 +766,7 @@ class EdgeView(Set, Mapping):
 class EdgeDataView:
     """EdgeDataView for edges of Hypergraph"""
 
-    __slots__ = ("_edge_attrs", "_data", "_default")
+    __slots__ = ("_edge_attr", "_data", "_default")
 
     def __getstate__(self):
         """Function that allows pickling of the edge data (write)
@@ -776,7 +779,7 @@ class EdgeDataView:
         """
         self._n
         return {
-            "_edge_attrs": self._edge_attrs,
+            "_edge_attr": self._edge_attr,
             "_data": self._data,
             "_default": self._default,
         }
@@ -790,7 +793,7 @@ class EdgeDataView:
             The keys access the edge attributes, the data key, and the default value respectively
             and the values are a dictionary, a hashable, and a hashable respectively.
         """
-        self._edge_attrs = state["_edge_attrs"]
+        self._edge_attr = state["_edge_attr"]
         self._data = state["_data"]
         self._default = state["_default"]
 
@@ -809,7 +812,7 @@ class EdgeDataView:
             The value to return if the attribute doesn't exist,
             by default None
         """
-        self._edge_attrs = edgedict
+        self._edge_attr = edgedict
         self._data = data
         self._default = default
 
@@ -821,7 +824,7 @@ class EdgeDataView:
         int
             The number of edges
         """
-        return len(self._edge_attrs)
+        return len(self._edge_attr)
 
     def __iter__(self):
         """Returns an iterator over edge IDs
@@ -836,12 +839,12 @@ class EdgeDataView:
         """
         data = self._data
         if data is False:
-            return iter(self._edge_attrs)
+            return iter(self._edge_attr)
         if data is True:
-            return iter(self._edge_attrs.items())
+            return iter(self._edge_attr.items())
         return (
             (e, dd[data] if data in dd else self._default)
-            for e, dd in self._edge_attrs.items()
+            for e, dd in self._edge_attr.items()
         )
 
     def __contains__(self, e):
@@ -857,7 +860,7 @@ class EdgeDataView:
         bool
             True if the edge ID is in the hypergraph, False if note.
         """
-        return e in self._edge_attrs
+        return e in self._edge_attr
 
     def __getitem__(self, e):
         """Get the data from an edge.
@@ -884,10 +887,10 @@ class EdgeDataView:
                 f"{type(self).__name__} does not support slicing, "
                 f"try list(H.nodes.data())[{e.start}:{e.stop}:{e.step}]"
             )
-        elif e not in self._edge_attrs:
+        elif e not in self._edge_attr:
             raise XGIError(f"The edge ID {e} is not in the hypergraph")
 
-        ddict = self._edge_attrs[e]
+        ddict = self._edge_attr[e]
         data = self._data
         if data is False:
             return dict()
@@ -936,7 +939,7 @@ class DegreeView:
     DegreeView can still lookup any node even if nbunch is specified.
     """
 
-    __slots__ = ("_hypergraph", "_nodes", "_edges", "_edge_attrs", "_weight")
+    __slots__ = ("_hypergraph", "_nodes", "_edges", "_edge_attr", "_weight")
 
     def __init__(self, H, nbunch=None, weight=None):
         """Initialize the DegreeView object
@@ -957,7 +960,7 @@ class DegreeView:
             else {id: val for id, val in H.nodes.items() if id in nbunch}
         )
         self._edges = H.edges
-        self._edge_attrs = H._edge_attr
+        self._edge_attr = H._edge_attr
         self._weight = weight
 
     def __call__(self, nbunch=None, weight=None):
@@ -1004,7 +1007,7 @@ class DegreeView:
         weight = self._weight
         if weight is None:
             return len(self._nodes(n))
-        return sum(self._edge_attrs[dd].get(weight, 1) for dd in self._nodes(n))
+        return sum(self._edge_attr[dd].get(weight, 1) for dd in self._nodes(n))
 
     def __iter__(self):
         """Returns an iterator of node ID, node degree pairs.
@@ -1017,11 +1020,11 @@ class DegreeView:
         weight = self._weight
         if weight is None:
             for n in self._nodes:
-                yield (n, len(self._nodes(n)))
+                yield (n, len(self._nodes.members(n)))
         else:
             for n in self._nodes:
                 elements = self._nodes(n)
-                deg = sum(self._edge_attrs[dd].get(weight, 1) for dd in elements)
+                deg = sum(self._edge_attr[dd].get(weight, 1) for dd in elements)
                 yield (n, deg)
 
     def __len__(self):
@@ -1070,7 +1073,7 @@ class EdgeSizeView:
     EdgeSizeView can still lookup any node even if nbunch is specified.
     """
 
-    __slots__ = ("_hypergraph", "_edges", "_nodes", "_node_attrs", "_weight")
+    __slots__ = ("_hypergraph", "_edges", "_nodes", "_node_attr", "_weight")
 
     def __init__(self, H, nbunch=None, weight=None):
         """Initialize
@@ -1091,7 +1094,7 @@ class EdgeSizeView:
             else {id: val for id, val in H.edges.items() if id in nbunch}
         )
         self._nodes = H.nodes
-        self._node_attrs = H._node_attr
+        self._node_attr = H._node_attr
         self._weight = weight
 
     def __call__(self, nbunch=None, weight=None):
@@ -1138,7 +1141,7 @@ class EdgeSizeView:
         weight = self._weight
         if weight is None:
             return len(self._edges(e))
-        return sum(self._node_attrs[dd].get(weight, 1) for dd in self._edges(e))
+        return sum(self._node_attr[dd].get(weight, 1) for dd in self._edges(e))
 
     def __iter__(self):
         """Returns an iterator over edge ID, edge size pairs.
@@ -1152,11 +1155,11 @@ class EdgeSizeView:
         weight = self._weight
         if weight is None:
             for e in self._edges:
-                yield (e, len(self._edges(e)))
+                yield (e, len(self._edges.members(e)))
         else:
             for e in self._edges:
                 elements = self._edges(e)
-                deg = sum(self._node_attrs[dd].get(weight, 1) for dd in elements)
+                deg = sum(self._node_attr[dd].get(weight, 1) for dd in elements)
                 yield (e, deg)
 
     def __len__(self):

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -316,6 +316,9 @@ class NodeView(Mapping, Set):
             raise XGIError(f"The node {n} is not in the hypergraph")
         return self._nodes[n]
 
+    membership = members
+
+
 
 class NodeDataView(Set):
     """A DataView class for nodes of a Hypergraph

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -223,7 +223,7 @@ class IDView(Mapping, Set):
             elif id not in self._ids:
                 raise XGIError(f"The ID {id} is not in the hypergraph")
 
-    membership = members
+    memberships = members
 
 
 # ID Degree View Base Class
@@ -255,7 +255,8 @@ class IDDegreeView:
         weight : hashable, optional
             The name of the attribute to weight the degree, by default None.
         """
-        self._ids = (ids
+        self._ids = (
+            ids
             if id_bunch is None
             else {id: val for id, val in ids.items() if id in id_bunch}
         )
@@ -350,18 +351,26 @@ class IDDegreeView:
         """
         return f"{self.__class__.__name__}({dict(self)})"
 
+
 class NodeView(IDView):
     def __init__(self, hypergraph):
         super(NodeView, self).__init__(hypergraph._node, hypergraph._node_attr)
+
 
 class EdgeView(IDView):
     def __init__(self, hypergraph):
         super(EdgeView, self).__init__(hypergraph._edge, hypergraph._edge_attr)
 
+
 class DegreeView(IDDegreeView):
     def __init__(self, hypergraph, nbunch=None, weight=None):
-        super().__init__(hypergraph._node, hypergraph._edge_attr, id_bunch=nbunch, weight=weight)
+        super().__init__(
+            hypergraph._node, hypergraph._edge_attr, id_bunch=nbunch, weight=weight
+        )
+
 
 class EdgeSizeView(IDDegreeView):
     def __init__(self, hypergraph, ebunch=None, weight=None):
-        super().__init__(hypergraph._edge, hypergraph._node_attr, id_bunch=ebunch, weight=weight)
+        super().__init__(
+            hypergraph._edge, hypergraph._node_attr, id_bunch=ebunch, weight=weight
+        )

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -151,13 +151,13 @@ class IDView(Mapping, Set):
         try:
             return self._id_attrs[id]
         except KeyError:
+            raise XGIError(f"The ID {id} is not in the hypergraph")
+        except:
             if isinstance(id, slice):
                 raise XGIError(
                     f"{type(self).__name__} does not support slicing, "
                     f"try list(H.nodes)[{id.start}:{id.stop}:{id.step}]"
                 )
-            elif id not in self._ids:
-                raise XGIError(f"The ID {id} is not in the hypergraph")
 
     # Set methods
     def __contains__(self, id):
@@ -353,13 +353,13 @@ class NodeView(IDView):
         try:
             return self._ids[n]
         except KeyError:
+            raise XGIError(f"The node ID {n} is not in the hypergraph")
+        except TypeError:
             if isinstance(n, slice):
                 raise XGIError(
                     f"{type(self).__name__} does not support slicing, "
                     f"try list(H.nodes)[{n.start}:{n.stop}:{n.step}]"
                 )
-            elif n not in self._ids:
-                raise XGIError(f"The node ID {n} is not in the hypergraph")
 
 
 class EdgeView(IDView):
@@ -395,13 +395,13 @@ class EdgeView(IDView):
         try:
             return self._ids[e]
         except KeyError:
+            raise XGIError(f"The edge ID {e} is not in the hypergraph")
+        except TypeError:
             if isinstance(e, slice):
                 raise XGIError(
                     f"{type(self).__name__} does not support slicing, "
                     f"try list(H.edges)[{e.start}:{e.stop}:{e.step}]"
                 )
-            elif e not in self._ids:
-                raise XGIError(f"The edge ID {e} is not in the hypergraph")
 
 class DegreeView(IDDegreeView):
     """ Class for representing the degrees.

--- a/xgi/generators/nonuniform.py
+++ b/xgi/generators/nonuniform.py
@@ -51,12 +51,12 @@ def erdos_renyi_hypergraph(n, m, p):
 
     if p < 0.0 or p > 1.0:
         raise ValueError("Invalid p value.")
-    
+
     if p == 0.0:
         H = xgi.empty_hypergraph()
         H.add_nodes_from(range(n))
         return H
-    
+
     # this corresponds to a completely filled incidence matrix,
     # not a complete hypergraph.
     if p == 1.0:

--- a/xgi/linalg/matrix.py
+++ b/xgi/linalg/matrix.py
@@ -73,7 +73,7 @@ def incidence_matrix(H, sparse=True, index=False, weight=lambda node, edge, H: 1
             # Create an np.matrix
             I = np.zeros((num_nodes, num_edges), dtype=int)
             for edge in H.edges:
-                members = H.edges[edge]
+                members = H.edges.members(edge)
                 for node in members:
                     I[node_dict[node], edge_dict[edge]] = weight(node, edge, H)
         if index:

--- a/xgi/linalg/matrix.py
+++ b/xgi/linalg/matrix.py
@@ -63,7 +63,7 @@ def incidence_matrix(H, sparse=True, index=False, weight=lambda node, edge, H: 1
             cols = list()
             data = list()
             for edge in H.edges:
-                members = H.edges[edge]
+                members = H.edges.members(edge)
                 for node in members:
                     data.append(weight(node, edge, H))
                     rows.append(node_dict[node])

--- a/xgi/readwrite/bipartite.py
+++ b/xgi/readwrite/bipartite.py
@@ -24,7 +24,7 @@ def generate_bipartite_edgelist(H, delimiter=" "):
         Each entry is a line to be written to the output file.
     """
     for id in H.edges:
-        for node in H.edges[id]:
+        for node in H.edges.members(id):
             yield delimiter.join(map(str, [node, id]))
 
 

--- a/xgi/readwrite/edgelist.py
+++ b/xgi/readwrite/edgelist.py
@@ -40,15 +40,15 @@ def generate_edgelist(H, delimiter=" ", data=True):
     """
     if data is True:
         for id in H.edges:
-            e = *H.edges[id], dict(H._edge_attr[id])
+            e = *H.edges.members(id), dict(H._edge_attr[id])
             yield delimiter.join(map(str, e))
     elif data is False:
         for id in H.edges:
-            e = H.edges[id]
+            e = H.edges.members(id)
             yield delimiter.join(map(str, e))
     else:
         for id in H.edges:
-            e = H.edges[id]
+            e = H.edges.members(id)
             try:
                 e.extend([H._edge_attr[id][k] for k in data])
             except KeyError:

--- a/xgi/readwrite/json.py
+++ b/xgi/readwrite/json.py
@@ -42,7 +42,7 @@ def write_hypergraph_json(H, path):
     data["hyperedge-data"] = {id: H._edge_attr[id] for id in H.edges}
 
     # hyperedge list
-    data["hyperedges"] = {id: tuple(H.edges[id]) for id in H.edges}
+    data["hyperedges"] = {id: tuple(H.edges.members(id)) for id in H.edges}
 
     datastring = json.dumps(data)
 


### PR DESCRIPTION
This one is pretty big so I suggest reviewing each commit in turn instead of the whole thing at once. This basically implements the behavior discussed here #40. In particular, there is (hopefully, I think), one way of accessing each thing. Among other things:

* `H['attr']` accesses hypergraph attributes.
* `H.nodes()` and `H.edges()` are no longer supported
* `H.nodes[]` and `H.edges[]` now access attributes
* `H.nodes.membership` is now the same as `H.nodes.members`. (I decided to keep members for simplicity and symmetry with `H.edges`)

There are a few kinks to work out, but I thought this PR was already big enough.

**As you review, please let me know if you think of any other test I should add to this PR.**

Also: there's a lot of noise in this PR because I decided to change `*_attrs` to `*_attr` just to be uniform with the variable names in the main `Hypergraph` class.

Closes #40 