### PR TITLE
Remove features

### DIFF
--- a/tests/classes/test_function.py
+++ b/tests/classes/test_function.py
@@ -78,12 +78,12 @@ def test_create_empty_copy(edgelist1):
     E1 = xgi.create_empty_copy(H, with_data=False)
     E2 = xgi.create_empty_copy(H)
 
-    assert E1.shape == (8, 0)
+    assert (E1.number_of_nodes(), E1.number_of_edges()) == (8, 0)
     for node in E1.nodes:
         assert len(E1.nodes.memberships(node)) == 0
     assert E1._hypergraph == {}
 
-    assert E2.shape == (8, 0)
+    assert (E2.number_of_nodes(), E2.number_of_edges()) == (8, 0)
     for node in E2.nodes:
         assert len(E1.nodes.memberships(node)) == 0
     assert E2["name"] == "test"

--- a/tests/classes/test_function.py
+++ b/tests/classes/test_function.py
@@ -78,12 +78,12 @@ def test_create_empty_copy(edgelist1):
     E1 = xgi.create_empty_copy(H, with_data=False)
     E2 = xgi.create_empty_copy(H)
 
-    assert (E1.number_of_nodes(), E1.number_of_edges()) == (8, 0)
+    assert (E1.num_nodes, E1.num_edges) == (8, 0)
     for node in E1.nodes:
         assert len(E1.nodes.memberships(node)) == 0
     assert E1._hypergraph == {}
 
-    assert (E2.number_of_nodes(), E2.number_of_edges()) == (8, 0)
+    assert (E2.num_nodes, E2.num_edges) == (8, 0)
     for node in E2.nodes:
         assert len(E1.nodes.memberships(node)) == 0
     assert E2["name"] == "test"

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -9,7 +9,6 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
     H_mat = xgi.Hypergraph(incidence5)
     H_df = xgi.Hypergraph(dataframe5)
 
-    assert H_list.shape == H_dict.shape == H_mat.shape == H_df.shape
     assert (
         list(H_list.nodes)
         == list(H_dict.nodes)
@@ -66,15 +65,6 @@ def test_len(edgelist1, edgelist2):
     assert len(H2) == 6
 
 
-def test_shape(edgelist1, edgelist2):
-    el1 = edgelist1
-    el2 = edgelist2
-    H1 = xgi.Hypergraph(el1)
-    H2 = xgi.Hypergraph(el2)
-    assert H1.shape == (8, 4)
-    assert H2.shape == (6, 3)
-
-
 def test_neighbors(edgelist1, edgelist2):
     el1 = edgelist1
     el2 = edgelist2
@@ -98,9 +88,9 @@ def test_dual(edgelist1, edgelist2, edgelist4):
     D1 = H1.dual()
     D2 = H2.dual()
     D3 = H3.dual()
-    assert D1.shape == (4, 8)
-    assert D2.shape == (3, 6)
-    assert D3.shape == (3, 5)
+    assert (D1.number_of_nodes(), D1.number_of_edges()) == (4, 8)
+    assert (D2.number_of_nodes(), D2.number_of_edges()) == (3, 6)
+    assert (D3.number_of_nodes(), D3.number_of_edges()) == (3, 5)
 
 
 def test_max_edge_order(edgelist1, edgelist4, edgelist5):

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -88,9 +88,9 @@ def test_dual(edgelist1, edgelist2, edgelist4):
     D1 = H1.dual()
     D2 = H2.dual()
     D3 = H3.dual()
-    assert (D1.number_of_nodes(), D1.number_of_edges()) == (4, 8)
-    assert (D2.number_of_nodes(), D2.number_of_edges()) == (3, 6)
-    assert (D3.number_of_nodes(), D3.number_of_edges()) == (3, 5)
+    assert (D1.num_nodes, D1.num_edges) == (4, 8)
+    assert (D2.num_nodes, D2.num_edges) == (3, 6)
+    assert (D3.num_nodes, D3.num_edges) == (3, 5)
 
 
 def test_max_edge_order(edgelist1, edgelist4, edgelist5):

--- a/tests/generators/test_classic.py
+++ b/tests/generators/test_classic.py
@@ -3,4 +3,4 @@ import xgi
 
 def test_empty_hypergraph():
     H = xgi.empty_hypergraph()
-    assert (H.number_of_nodes(), H.number_of_edges()) == (0, 0)
+    assert (H.num_nodes, H.num_edges) == (0, 0)

--- a/tests/generators/test_classic.py
+++ b/tests/generators/test_classic.py
@@ -3,4 +3,4 @@ import xgi
 
 def test_empty_hypergraph():
     H = xgi.empty_hypergraph()
-    assert H.shape == (0, 0)
+    assert (H.number_of_nodes(), H.number_of_edges()) == (0, 0)

--- a/tests/generators/test_nonuniform.py
+++ b/tests/generators/test_nonuniform.py
@@ -8,7 +8,7 @@ def test_chung_lu_hypergraph():
     k1 = {1: 1, 2: 2, 3: 3, 4: 4}
     k2 = {1: 2, 2: 2, 3: 3, 4: 3}
     H = xgi.chung_lu_hypergraph(k1, k2)
-    assert H.number_of_nodes() == 4
+    assert H.num_nodes == 4
 
     with pytest.warns(Warning):
         k1 = {1: 1, 2: 2}

--- a/tests/generators/test_nonuniform.py
+++ b/tests/generators/test_nonuniform.py
@@ -4,24 +4,6 @@ import pytest
 from xgi.exception import XGIError
 
 
-def test_erdos_renyi_hypergraph():
-    with pytest.raises(ValueError):
-        H = xgi.erdos_renyi_hypergraph(10, 20, -0.1)
-    with pytest.raises(ValueError):
-        H = xgi.erdos_renyi_hypergraph(10, 20, 2.0)
-
-    H = xgi.erdos_renyi_hypergraph(10, 20, 0.0)
-    assert H.number_of_nodes() == 10
-    assert H.number_of_edges() == 0
-
-    H = xgi.erdos_renyi_hypergraph(10, 20, 1.0)
-    assert H.number_of_nodes() == 10
-    assert H.number_of_edges() == 20
-
-    H = xgi.erdos_renyi_hypergraph(10, 20, 0.1)
-    assert H.number_of_nodes() == 10
-
-
 def test_chung_lu_hypergraph():
     k1 = {1: 1, 2: 2, 3: 3, 4: 4}
     k2 = {1: 2, 2: 2, 3: 3, 4: 3}

--- a/tests/generators/test_uniform.py
+++ b/tests/generators/test_uniform.py
@@ -7,9 +7,9 @@ def test_uniform_configuration_model_hypergraph():
     m = 3
     k = {1: 1, 2: 2, 3: 3, 4: 3}
     H = xgi.uniform_hypergraph_configuration_model(k, m)
-    assert H.number_of_nodes() == 4
+    assert H.num_nodes == 4
     assert dict(H.degree) == k
-    assert H.number_of_edges() == 3
+    assert H.num_edges == 3
 
     with pytest.warns(Warning):
         m = 3

--- a/tutorials/Tutorial 1 - Basic Hypergraph Functionality.ipynb
+++ b/tutorials/Tutorial 1 - Basic Hypergraph Functionality.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,12 +77,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The hypergraph has 1000 nodes and 1000 edges\n"
+     ]
+    }
+   ],
    "source": [
     "H = xgi.Hypergraph(hyperedge_list)\n",
-    "print(f\"The hypergraph has {H.number_of_nodes()} nodes and {H.number_of_edges()} edges\")"
+    "print(f\"The hypergraph has {H.num_nodes} nodes and {H.num_edges} edges\")"
    ]
   },
   {
@@ -96,12 +104,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The hypergraph has 1000 nodes and 1000 edges\n"
+     ]
+    }
+   ],
    "source": [
     "H = xgi.Hypergraph(hyperedge_dict)\n",
-    "print(f\"The hypergraph has {H.number_of_nodes()} nodes and {H.number_of_edges()} edges\")"
+    "print(f\"The hypergraph has {H.num_nodes} nodes and {H.num_edges} edges\")"
    ]
   },
   {
@@ -115,12 +131,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The hypergraph has 1000 nodes and 1000 edges\n"
+     ]
+    }
+   ],
    "source": [
     "H = xgi.Hypergraph(incidence_matrix)\n",
-    "print(f\"The hypergraph has {H.number_of_nodes()} nodes and {H.number_of_edges()} edges\")"
+    "print(f\"The hypergraph has {H.num_nodes} nodes and {H.num_edges} edges\")"
    ]
   },
   {
@@ -133,12 +157,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The hypergraph has 12368 nodes and 2261 edges\n"
+     ]
+    }
+   ],
    "source": [
     "H = xgi.Hypergraph(df)\n",
-    "print(f\"The hypergraph has {H.number_of_nodes()} nodes and {H.number_of_edges()} edges\")"
+    "print(f\"The hypergraph has {H.num_nodes} nodes and {H.num_edges} edges\")"
    ]
   },
   {
@@ -163,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,17 +227,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Testing whether the hypergraph is s-connected"
+    "### Testing whether the hypergraph is connected"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "n = 1000\n",
-    "m = 1000\n",
+    "m = 100\n",
     "\n",
     "min_edge_size = 2\n",
     "max_edge_size = 10\n",
@@ -217,9 +249,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "H is not connected\n",
+      "The sizes of the connected components are:\n",
+      "[446, 2, 3, 3, 4, 5, 2, 3, 2]\n",
+      "The size of the component containing node 0 is 446\n"
+     ]
+    }
+   ],
    "source": [
     "is_connected = xgi.is_connected(H)\n",
     "if is_connected:\n",
@@ -245,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,6 +322,13 @@
     "# Convert to an incidence matrix\n",
     "h_I = xgi.to_incidence_matrix(H)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -37,7 +37,7 @@ def degree_histogram(H):
     Notes
     -----
     Note: the bins are width one, hence len(list) can be large
-    (Order(number_of_edges))
+    (Order(num_edges))
 
     Examples
     --------

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -120,7 +120,6 @@ class Hypergraph:
         See Also
         --------
         number_of_nodes: identical method
-        order: identical method
         """
         return len(self._node)
 
@@ -134,25 +133,6 @@ class Hypergraph:
     def __setitem__(self, attr, val):
         """Write hypergraph attribute."""
         self._hypergraph[attr] = val
-
-    @property
-    def shape(self):
-        """Return the number of nodes and edges as a tuple.
-
-        Returns
-        -------
-        tuple
-           A tuple of the number of nodes and edges respectively.
-
-        Examples
-        --------
-        >>> import xgi
-        >>> hyperedge_list = [[1, 2], [2, 3, 4]]
-        >>> H = xgi.Hypergraph(hyperedge_list)
-        >>> H.shape
-        (4, 2)
-        """
-        return len(self._node), len(self._edge)
 
     def neighbors(self, n):
         """Find the neighbors of a specified node.
@@ -341,7 +321,6 @@ class Hypergraph:
 
         See Also
         --------
-        order: identical method
         __len__: identical method
 
         Examples
@@ -350,29 +329,6 @@ class Hypergraph:
         >>> hyperedge_list = [[1, 2], [2, 3, 4]]
         >>> H = xgi.Hypergraph(hyperedge_list)
         >>> H.number_of_nodes()
-        4
-        """
-        return len(self._node)
-
-    def order(self):
-        """Returns the number of nodes in the hypergraph.
-
-        Returns
-        -------
-        int
-            The number of nodes in the hypergraph.
-
-        See Also
-        --------
-        number_of_nodes: identical method
-        __len__: identical method
-
-        Examples
-        --------
-        >>> import xgi
-        >>> hyperedge_list = [[1, 2], [2, 3, 4]]
-        >>> H = xgi.Hypergraph(hyperedge_list)
-        >>> H.order()
         4
         """
         return len(self._node)

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -77,9 +77,9 @@ class Hypergraph:
 
         """
         try:
-            return f"{type(self).__name__} named {self['name']} with {self.number_of_nodes()} nodes and {self.number_of_edges()} hyperedges"
+            return f"{type(self).__name__} named {self['name']} with {self.num_nodes} nodes and {self.num_edges} hyperedges"
         except:
-            return f"Unnamed {type(self).__name__} with {self.number_of_nodes()} nodes and {self.number_of_edges()} hyperedges"
+            return f"Unnamed {type(self).__name__} with {self.num_nodes} nodes and {self.num_edges} hyperedges"
 
     def __iter__(self):
         """Iterate over the nodes. Use: 'for n in H'.
@@ -119,7 +119,7 @@ class Hypergraph:
 
         See Also
         --------
-        number_of_nodes: identical method
+        num_nodes: identical method
         """
         return len(self._node)
 
@@ -133,6 +133,53 @@ class Hypergraph:
     def __setitem__(self, attr, val):
         """Write hypergraph attribute."""
         self._hypergraph[attr] = val
+
+    @property
+    def num_nodes(self):
+        """Returns the number of nodes in the hypergraph.
+
+        Returns
+        -------
+        int
+            The number of nodes in the hypergraph.
+
+        See Also
+        --------
+        __len__: identical method
+        num_edges : returns the number of edges in the hypergraph
+
+        Examples
+        --------
+        >>> import xgi
+        >>> hyperedge_list = [[1, 2], [2, 3, 4]]
+        >>> H = xgi.Hypergraph(hyperedge_list)
+        >>> H.num_nodes
+        4
+        """
+        return len(self._node)
+
+    @property
+    def num_edges(self):
+        """Returns the number of edges in the hypergraph.
+
+        Returns
+        -------
+        int
+            The number of edges in the hypergraph.
+
+        See Also
+        --------
+        num_nodes : returns the number of nodes in the hypergraph
+
+        Examples
+        --------
+        >>> import xgi
+        >>> hyperedge_list = [[1, 2], [2, 3, 4]]
+        >>> H = xgi.Hypergraph(hyperedge_list)
+        >>> H.num_edges
+        2
+        """
+        return len(self._edge)
 
     def neighbors(self, n):
         """Find the neighbors of a specified node.
@@ -310,28 +357,6 @@ class Hypergraph:
         # setattr doesn't work because attribute already exists
         self.__dict__["nodes"] = nodes
         return nodes
-
-    def number_of_nodes(self):
-        """Returns the number of nodes in the hypergraph.
-
-        Returns
-        -------
-        int
-            The number of nodes in the hypergraph.
-
-        See Also
-        --------
-        __len__: identical method
-
-        Examples
-        --------
-        >>> import xgi
-        >>> hyperedge_list = [[1, 2], [2, 3, 4]]
-        >>> H = xgi.Hypergraph(hyperedge_list)
-        >>> H.number_of_nodes()
-        4
-        """
-        return len(self._node)
 
     def has_node(self, n):
         """Returns True if the hypergraph contains the node n.
@@ -968,28 +993,6 @@ class Hypergraph:
         """
         subhypergraph = xgi.hypergraphviews.subhypergraph_view
         return subhypergraph(self, nodes, edges)
-
-    def number_of_edges(self):
-        """Returns the number of edges in the hypergraph.
-
-        Returns
-        -------
-        int
-            The number of edges in the hypergraph.
-
-        See Also
-        --------
-        number_of_nodes : returns the number of nodes in the hypergraph
-
-        Examples
-        --------
-        >>> import xgi
-        >>> hyperedge_list = [[1, 2], [2, 3, 4]]
-        >>> H = xgi.Hypergraph(hyperedge_list)
-        >>> H.number_of_edges()
-        2
-        """
-        return len(self._edge)
 
     def nbunch_iter(self, nbunch=None):
         """Returns an iterator over nodes contained in nbunch that are

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -414,10 +414,8 @@ def to_bipartite_graph(H):
     """
     G = nx.Graph()
 
-    num_nodes = H.number_of_nodes()
-    num_edges = H.number_of_edges()
-    node_dict = dict(zip(H.nodes, range(num_nodes)))
-    edge_dict = dict(zip(H.edges, range(num_nodes, num_nodes + num_edges)))
+    node_dict = dict(zip(H.nodes, range(H.num_nodes)))
+    edge_dict = dict(zip(H.edges, range(H.num_nodes, H.num_nodes + H.num_edges)))
     G.add_nodes_from(node_dict.values(), bipartite=0)
     G.add_nodes_from(edge_dict.values(), bipartite=1)
     for node in H.nodes:
@@ -426,6 +424,6 @@ def to_bipartite_graph(H):
 
     return (
         G,
-        dict(zip(range(num_nodes), H.nodes)),
-        dict(zip(range(num_nodes, num_nodes + num_edges), H.edges)),
+        dict(zip(range(H.num_nodes), H.nodes)),
+        dict(zip(range(H.num_nodes, H.num_nodes + H.num_edges), H.edges)),
     )

--- a/xgi/generators/classic.py
+++ b/xgi/generators/classic.py
@@ -30,9 +30,9 @@ def empty_hypergraph(create_using=None, default=Hypergraph):
     --------
     >>> import xgi
     >>> H = xgi.empty_hypergraph()
-    >>> H.number_of_nodes()
+    >>> H.num_nodes
     0
-    >>> H.number_of_edges()
+    >>> H.num_edges
     0
     """
     if create_using is None:

--- a/xgi/generators/nonuniform.py
+++ b/xgi/generators/nonuniform.py
@@ -13,6 +13,7 @@ __all__ = [
     "random_hypergraph",
 ]
 
+
 def chung_lu_hypergraph(k1, k2):
     """A function to generate a Chung-Lu hypergraph
 

--- a/xgi/generators/nonuniform.py
+++ b/xgi/generators/nonuniform.py
@@ -8,74 +8,10 @@ import xgi
 
 
 __all__ = [
-    "erdos_renyi_hypergraph",
     "chung_lu_hypergraph",
     "dcsbm_hypergraph",
     "random_hypergraph",
 ]
-
-
-def erdos_renyi_hypergraph(n, m, p):
-    """A function to generate an Erdos-Renyi hypergraph
-
-    Parameters
-    ----------
-    n: int
-        Number of nodes
-    m: int
-        Number of edges
-    p: float
-        The probability that a bipartite edge is created
-
-    Returns
-    -------
-    Hypergraph object
-        The generated hypergraph
-
-    References
-    ----------
-    Implemented by Mirah Shi in HyperNetX and described for
-    bipartite networks by Aksoy et al. in https://doi.org/10.1093/comnet/cnx001
-
-    Examples
-    --------
-    >>> import xgi
-    >>> n = 1000
-    >>> m = n
-    >>> p = 0.01
-    >>> H = xgi.erdos_renyi_hypergraph(n, m, p)
-    """
-
-    H = xgi.empty_hypergraph()
-    H.add_nodes_from(range(n))
-
-    if p < 0.0 or p > 1.0:
-        raise ValueError("Invalid p value.")
-
-    if p == 0.0:
-        H = xgi.empty_hypergraph()
-        H.add_nodes_from(range(n))
-        return H
-
-    # this corresponds to a completely filled incidence matrix,
-    # not a complete hypergraph.
-    if p == 1.0:
-        H = xgi.empty_hypergraph()
-        H.add_edges_from([range(n) for i in range(m)])
-        return H
-
-    for u in range(n):
-        v = 0
-        while v < m:
-            # identify next pair
-            r = random.random()
-            v = v + math.floor(math.log(r) / math.log(1 - p))
-            if v < m:
-                # add vertex hyperedge pair
-                H.add_node_to_edge(v, u)
-            v = v + 1
-    return H
-
 
 def chung_lu_hypergraph(k1, k2):
     """A function to generate a Chung-Lu hypergraph


### PR DESCRIPTION
* Removed the `shape` property and the `order()` and `erdos_renyi_hypergraph()` methods as well as their associated unit tests
* Renamed `number_of_nodes()` and `number_of_edges()` to `num_nodes` and `num_edges` respectively and made them both properties for concision.
* Formatted with black.
* All unit tests pass.