### PR TITLE
Add IDDict which takes care of data validation and raising appropriate errors

### DIFF
--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -1,6 +1,6 @@
 import pytest
 import xgi
-from xgi.exception import XGIError
+from xgi.exception import XGIError, IDNotFound
 
 
 def test_constructor(edgelist5, dict5, incidence5, dataframe5):
@@ -181,7 +181,7 @@ def test_members(edgelist1):
     assert H.nodes.memberships(3) == [0]
     assert H.nodes.memberships(4) == [1]
     assert H.nodes.memberships(6) == [2, 3]
-    with pytest.raises(XGIError):
+    with pytest.raises(IDNotFound):
         H.nodes.memberships(0)
     with pytest.raises(XGIError):
         H.nodes.memberships(slice(1, 4))
@@ -202,5 +202,5 @@ def test_egonet(edgelist3):
     assert H.neighbors(3) == {1, 2, 4}
     assert H.egonet(3) == [[1, 2], [4]]
     assert H.egonet(3, include_self=True) == [[1, 2, 3], [3, 4]]
-    with pytest.raises(XGIError):
+    with pytest.raises(IDNotFound):
         H.egonet(7)

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -150,9 +150,7 @@ class IDView(Mapping, Set):
         """
         try:
             return self._id_attrs[id]
-        except KeyError:
-            raise XGIError(f"The ID {id} is not in the hypergraph")
-        except:
+        except ValueError:
             if isinstance(id, slice):
                 raise XGIError(
                     f"{type(self).__name__} does not support slicing, "
@@ -353,8 +351,6 @@ class NodeView(IDView):
         """
         try:
             return self._ids[n]
-        except KeyError:
-            raise XGIError(f"The node ID {n} is not in the hypergraph")
         except TypeError:
             if isinstance(n, slice):
                 raise XGIError(
@@ -408,8 +404,6 @@ class EdgeView(IDView):
 
         try:
             return self._ids[e]
-        except KeyError:
-            raise XGIError(f"The edge ID {e} is not in the hypergraph")
         except TypeError:
             if isinstance(e, slice):
                 raise XGIError(

--- a/xgi/exception.py
+++ b/xgi/exception.py
@@ -4,3 +4,7 @@ class XGIException(Exception):
 
 class XGIError(XGIException):
     """Exception for a serious error in XGI"""
+
+
+class IDNotFound(XGIException):
+    """Raised when a node or edge is not in the hypergraph."""


### PR DESCRIPTION
Currently in several places of the code we have a version of the following code:
```python
if node not in self._node:
    raise XGIError("Node not in hypergraph")
```
Of course, this is not done every time it should be done, and the error message is always different. Sometimes the node is checked not only for membership but also it is checked that it does not equal None. But this practice is inconsistent. So I decided to abstract this out into a class `IDDict` that performs the data validation and then just acts as a usual dictionary. Added some tests to that effect.

I think the code node is cleaner and in the future we won't need to remember about data validation anymore. Or we can just modify the `IDDict` class instead of having to modify multiple try/except blocks.