### PR TITLE
feat(api)!: Changed api of degree_histogram and added degree_counts based on #23

### DIFF
--- a/tests/classes/test_function.py
+++ b/tests/classes/test_function.py
@@ -4,14 +4,14 @@ import xgi
 from xgi.exception import IDNotFound, XGIError
 
 
-def test_degree_histogram(edgelist1, edgelist2, edgelist3):
+def test_degree_counts(edgelist1, edgelist2, edgelist3):
     H1 = xgi.Hypergraph(edgelist1)
     H2 = xgi.Hypergraph(edgelist2)
     H3 = xgi.Hypergraph(edgelist3)
 
-    assert xgi.degree_histogram(H1) == [0, 7, 1]
-    assert xgi.degree_histogram(H2) == [0, 5, 1]
-    assert xgi.degree_histogram(H3) == [0, 4, 2]
+    assert xgi.degree_counts(H1) == [0, 7, 1]
+    assert xgi.degree_counts(H2) == [0, 5, 1]
+    assert xgi.degree_counts(H3) == [0, 4, 2]
 
 
 def test_unique_edge_sizes(edgelist1, edgelist2, edgelist4, edgelist5):

--- a/tests/classes/test_function.py
+++ b/tests/classes/test_function.py
@@ -14,6 +14,16 @@ def test_degree_counts(edgelist1, edgelist2, edgelist3):
     assert xgi.degree_counts(H3) == [0, 4, 2]
 
 
+def test_degree_histogram(edgelist1, edgelist2, edgelist3):
+    H1 = xgi.Hypergraph(edgelist1)
+    H2 = xgi.Hypergraph(edgelist2)
+    H3 = xgi.Hypergraph(edgelist3)
+
+    assert xgi.degree_histogram(H1) == ([1, 2], [7, 1])
+    assert xgi.degree_histogram(H2) == ([1, 2], [5, 1])
+    assert xgi.degree_histogram(H3) == ([1, 2], [4, 2])
+
+
 def test_unique_edge_sizes(edgelist1, edgelist2, edgelist4, edgelist5):
     H1 = xgi.Hypergraph(edgelist1)
     H2 = xgi.Hypergraph(edgelist2)

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 
-def degree_histogram(H):
+def degree_counts(H):
     """Returns a list of the frequency of each degree value.
 
     Parameters
@@ -44,11 +44,44 @@ def degree_histogram(H):
     >>> import xgi
     >>> hyperedge_list = [[1, 2], [2, 3, 4]]
     >>> H = xgi.Hypergraph(hyperedge_list)
-    >>> xgi.degree_histogram(H)
+    >>> xgi.degree_counts(H)
     [0, 3, 1]
     """
     counts = Counter(d for n, d in H.degree())
     return [counts.get(i, 0) for i in range(max(counts) + 1)]
+
+
+def degree_histogram(H):
+    """Returns a degree histogram including bin centers (degree values).
+
+    Parameters
+    ----------
+    H : Hypergraph object
+        The hypergraph of interest
+
+    Returns
+    -------
+    tuple of lists
+        First entry is degrees, second entry is histogram height
+    Notes
+    -----
+    Note: the bins are width one, hence there will be an entry
+    for every observed degree.
+
+    Examples
+    --------
+    >>> import xgi
+    >>> hyperedge_list = [[1, 2], [2, 3, 4]]
+    >>> H = xgi.Hypergraph(hyperedge_list)
+    >>> xgi.degree_histogram(H)
+    ([1, 2], [3, 1])
+    """
+    counts = Counter(d for n, d in H.degree())
+    degrees = []; heights = []
+    for d, c in sorted(counts.items(), key=lambda kv: kv[0]):
+        degrees.append(d)
+        heights.append(c)
+    return degrees, heights
 
 
 def unique_edge_sizes(H):

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -62,7 +62,8 @@ def degree_histogram(H):
     Returns
     -------
     tuple of lists
-        First entry is degrees, second entry is histogram height
+        First entry is observed degrees (bin centers),
+            second entry is degree count (histogram height)
     Notes
     -----
     Note: the bins are width one, hence there will be an entry

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -7,6 +7,7 @@ import xgi
 from xgi.exception import XGIError
 
 __all__ = [
+    "degree_counts",
     "degree_histogram",
     "unique_edge_sizes",
     "freeze",


### PR DESCRIPTION
Addresses #23.

I refactored the existing `degree_histogram` code into a function called `degree_counts`. I did not modify the behavior of `degree_counts` from the original `degree_histogram`.

I then wrote a new `degree_histogram` function that returns a `tuple` of 2 `list`s, where the first list corresponds to the observed degrees (bin centers for the histogram) in ascending order, and the second tuple is the number of nodes with the degree in the same index of the first list (heights of the histogram). Note that, unlike the behavior of `degree_counts`, I do not return entries with count 0, as there is no need to infer the degree from the list since I return the list of observed degrees explicitly. These lists can be passed directly to `matplotlib.pyplot.[bar | plot]` for visualization.

BREAKING CHANGE: Existing code using the old version of `degree_histogram` will now fail because the new `degree_histogram` returns a 2 tuple, not a list of degree values. Code using `degree_histogram` should be modified to use `degree_counts`.

Edit: The original issue (#23) asks to mimic the `np.unique` return - this pull request does achieve that, though it returns a tuple of lists, not an `np.array`. `numpy` is not being used in this file so I did not add the dependency and just used tuple of lists instead.