### PR TITLE
Refactor members

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ Community members asked to stop any inappropriate behavior are expected to compl
 
 This Code of Conduct applies to the following online spaces:
 
-- The [XGI GitHub Project](https://github.com/nwlandry/xgi)
+- The [XGI GitHub Project](https://github.com/ComplexGroupInteractions/xgi)
 
 This Code of Conduct applies to every member in official XGI Community online spaces, including:
 

--- a/benchmarks/benchmark.ipynb
+++ b/benchmarks/benchmark.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,24 +14,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fname = \"data/disGene.txt\"\n",
+    "fname = \"../data/disGene.txt\"\n",
     "df = pd.read_csv(fname, delimiter=\" \", header=None)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.33559584617614746\n"
+      "0.9091813564300537\n"
      ]
     },
     {
@@ -40,7 +40,7 @@
        "(2261, 12368)"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -50,19 +50,19 @@
     "H1 = xgi.Hypergraph(df)\n",
     "H1 = H1.dual()\n",
     "print(time.time() - start)\n",
-    "H1.shape"
+    "(H1.num_nodes, H1.num_edges)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "19.365208387374878\n"
+      "40.126617193222046\n"
      ]
     },
     {
@@ -71,7 +71,7 @@
        "(2261, 12368)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -85,15 +85,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.08783912658691406\n",
-      "0.001967906951904297\n"
+      "19.34950351715088\n",
+      "0.005000114440917969\n"
      ]
     }
    ],
@@ -109,15 +109,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.23723101615905762\n",
-      "5.207367420196533\n"
+      "0.6973035335540771\n",
+      "15.175977230072021\n"
      ]
     }
    ],
@@ -133,15 +133,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.15181589126586914\n",
-      "0.06401252746582031\n"
+      "18.94729518890381\n",
+      "0.1862046718597412\n"
      ]
     }
    ],
@@ -157,15 +157,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.14442706108093262\n",
-      "0.7197976112365723\n"
+      "0.22495102882385254\n",
+      "1.8861963748931885\n"
      ]
     }
    ],
@@ -181,41 +181,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.0019845962524414062\n",
-      "0.14178681373596191\n"
+      "0.12999200820922852\n",
+      "0.24797916412353516\n"
      ]
     }
    ],
    "source": [
     "start = time.time()\n",
     "for node in H1.nodes:\n",
-    "    a = H1.nodes[node]\n",
+    "    a = H1.nodes.memberships(node)\n",
     "print(time.time() - start)\n",
     "\n",
     "start = time.time()\n",
     "for node in H2.nodes:\n",
-    "    a = H2.nodes[node]\n",
+    "    a = H2.nodes.memberships[node]\n",
     "print(time.time() - start)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.2020864486694336\n",
-      "1.7170355319976807\n"
+      "2.4370179176330566\n",
+      "14.03342580795288\n"
+     ]
+    }
+   ],
+   "source": [
+    "start = time.time()\n",
+    "for edge in H1.edges:\n",
+    "    a = H1.edges.members(edge)\n",
+    "print(time.time() - start)\n",
+    "\n",
+    "start = time.time()\n",
+    "for node in H2.nodes:\n",
+    "    a = H2.edges[edge]\n",
+    "print(time.time() - start)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.6568243503570557\n",
+      "5.016293287277222\n"
      ]
     }
    ],

--- a/tests/classes/test_reportviews.py
+++ b/tests/classes/test_reportviews.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import xgi
-from xgi.exception import XGIError
+from xgi.exception import IDNotFound, XGIError
 
 
 def test_edge_order(edgelist3):
@@ -116,6 +116,17 @@ def test_edge_members(edgelist3):
     assert H.edges.members(0) == [1, 2, 3]
     assert H.edges.members() == [[1, 2, 3], [3, 4], [4, 5, 6]]
     assert H.edges.members(dtype=dict) == {0: [1, 2, 3], 1: [3, 4], 2: [4, 5, 6]}
+    with pytest.raises(XGIError) as exception_info:
+        H.edges.members(dtype=np.array)
+    assert "Unrecognized dtype" in str(exception_info.value)
+
+    with pytest.raises(XGIError) as exception_info:
+        H.edges.members(slice(1, 4, 1))
+    assert "try list(H.edges)[1:4:1]" in str(exception_info.value)
+
+    with pytest.raises(IDNotFound) as exception_info:
+        H.edges.members("test")
+    assert "Item test not in this view" == str(exception_info.value)
 
 
 def test_bunch_view(edgelist1):

--- a/xgi/algorithms/connected.py
+++ b/xgi/algorithms/connected.py
@@ -38,7 +38,7 @@ def is_connected(H):
     Example
     -------
     >>> import xgi
-    >>> H = xgi.random_hypergraph(10, [0.5, 0.01])
+    >>> H = xgi.random_hypergraph(10, [0.5, 0.01], seed=1)
     >>> print(xgi.is_connected(H))
     True
 
@@ -70,7 +70,7 @@ def connected_components(H):
     Example
     -------
     >>> import xgi
-    >>> H = xgi.random_hypergraph(50, [0.1, 0.01])
+    >>> H = xgi.random_hypergraph(50, [0.1, 0.01], seed=1)
     >>> print([len(component) for component in xgi.connected_components(H)])
     [50]
 
@@ -107,7 +107,7 @@ def number_connected_components(H):
     Example
     -------
     >>> import xgi
-    >>> H = xgi.random_hypergraph(50, [0.1, 0.01])
+    >>> H = xgi.random_hypergraph(50, [0.1, 0.01], seed=1)
     >>> print(xgi.number_connected_components(H))
     1
 
@@ -146,7 +146,7 @@ def largest_connected_component(H):
     Example
     -------
     >>> import xgi
-    >>> H = xgi.random_hypergraph(50, [0.1, 0.01])
+    >>> H = xgi.random_hypergraph(50, [0.1, 0.01], seed=1)
     >>> print(xgi.number_connected_components(H))
     1
 
@@ -179,7 +179,7 @@ def node_connected_component(H, n):
     Example
     -------
     >>> import xgi
-    >>> H = xgi.random_hypergraph(50, [0.1, 0.01])
+    >>> H = xgi.random_hypergraph(50, [0.1, 0.01], seed=1)
     >>> comp = xgi.node_connected_component(H, 0)
     >>> print(type(comp), len(comp))
     <class 'set'> 50
@@ -235,7 +235,7 @@ def largest_connected_hypergraph(H, in_place=False):
     Example
     -------
     >>> import xgi
-    >>> H = xgi.random_hypergraph(50, [0.1, 0.01])
+    >>> H = xgi.random_hypergraph(50, [0.1, 0.01], seed=1)
     >>> print(xgi.number_connected_components(H))
     1
     """

--- a/xgi/classes/__init__.py
+++ b/xgi/classes/__init__.py
@@ -2,5 +2,5 @@ from xgi.classes import hypergraphviews, reportviews
 
 from .function import *
 from .hypergraph import Hypergraph
-from .simplicialcomplex import SimplicialComplex
 from .hypergraphviews import subhypergraph
+from .simplicialcomplex import SimplicialComplex

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -413,17 +413,6 @@ class EdgeView(IDView):
             If `e` is a slice or if `e` does not exist in the hypergraph.
 
         """
-        if e is None:
-            if dtype is dict:
-                return {key: self._id_dict[key] for key in self._ids}
-            elif dtype is list:
-                return [self._id_dict[key] for key in self._ids]
-            else:
-                raise XGIError(f"Unrecognized dtype {dtype}")
-
-        if e not in self._ids:
-            raise IDNotFound(f"Item {e} not in this view")
-
         try:
             return self._id_dict[e].copy()
         except TypeError as e:
@@ -432,6 +421,15 @@ class EdgeView(IDView):
                     f"{type(self).__name__} does not support slicing, "
                     f"try list(H.edges)[{e.start}:{e.stop}:{e.step}]"
                 ) from e
+        except IDNotFound:
+            if e is None:
+                if dtype is dict:
+                    return {key: self._id_dict[key] for key in self._ids}
+                elif dtype is list:
+                    return [self._id_dict[key] for key in self._ids]
+                else:
+                    raise XGIError(f"Unrecognized dtype {dtype}")
+            raise IDNotFound(f"Item {e} not in this view")
 
 
 class DegreeView(IDDegreeView):

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -415,12 +415,12 @@ class EdgeView(IDView):
         """
         try:
             return self._id_dict[e].copy()
-        except TypeError as e:
+        except TypeError:
             if isinstance(e, slice):
                 raise XGIError(
                     f"{type(self).__name__} does not support slicing, "
                     f"try list(H.edges)[{e.start}:{e.stop}:{e.step}]"
-                ) from e
+                )
         except IDNotFound:
             if e is None:
                 if dtype is dict:

--- a/xgi/drawing/layout.py
+++ b/xgi/drawing/layout.py
@@ -1,7 +1,7 @@
 import networkx as nx
 
 import xgi
-from xgi.utils import py_random_state, np_random_state
+from xgi.utils import np_random_state, py_random_state
 
 __all__ = [
     "random_layout",

--- a/xgi/drawing/layout.py
+++ b/xgi/drawing/layout.py
@@ -1,7 +1,7 @@
 import networkx as nx
 
 import xgi
-from xgi.utils import np_random_state, py_random_state
+from xgi.utils import np_random_state
 
 __all__ = [
     "random_layout",


### PR DESCRIPTION
Improved the speed of the `members()` method in the `EdgeView` class by refactoring. Before refactoring, in the following list comprehension
`[H.edges.members(e) for e in H.edges]`
the `members()` method took 1.254s for 10885 function calls on the [email-enron dataset](https://github.com/ComplexGroupInteractions/xgi-data/blob/main/data/email-Enron/README_email-Enron.md). After refactoring, the same 10885 function calls took 0.014s. This refactor did not change the speed of `H.edges.members()`.