### PR TITLE
refactor: improve speed of accessing nodes and edges

### DIFF
--- a/benchmarks/benchmark.ipynb
+++ b/benchmarks/benchmark.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,14 +24,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.9091813564300537\n"
+      "0.7862493991851807\n"
      ]
     },
     {
@@ -40,7 +40,7 @@
        "(2261, 12368)"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -55,14 +55,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "40.126617193222046\n"
+      "26.969719409942627\n"
      ]
     },
     {
@@ -71,7 +71,7 @@
        "(2261, 12368)"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -85,15 +85,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "19.34950351715088\n",
-      "0.005000114440917969\n"
+      "0.21578502655029297\n",
+      "0.0030651092529296875\n"
      ]
     }
    ],
@@ -109,15 +109,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.6973035335540771\n",
-      "15.175977230072021\n"
+      "0.26488590240478516\n",
+      "7.163757801055908\n"
      ]
     }
    ],
@@ -133,15 +133,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "18.94729518890381\n",
-      "0.1862046718597412\n"
+      "0.2491471767425537\n",
+      "0.08088803291320801\n"
      ]
     }
    ],
@@ -157,15 +157,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.22495102882385254\n",
-      "1.8861963748931885\n"
+      "0.23104119300842285\n",
+      "1.052358865737915\n"
      ]
     }
    ],
@@ -181,15 +181,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.12999200820922852\n",
-      "0.24797916412353516\n"
+      "0.0077855587005615234\n",
+      "0.23103785514831543\n"
      ]
     }
    ],
@@ -207,15 +207,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.4370179176330566\n",
-      "14.03342580795288\n"
+      "0.020564794540405273\n",
+      "8.845157861709595\n"
      ]
     }
    ],
@@ -233,15 +233,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.6568243503570557\n",
-      "5.016293287277222\n"
+      "0.36504125595092773\n",
+      "2.280500650405884\n"
      ]
     }
    ],
@@ -261,7 +261,7 @@
    "hash": "e8c90be8a507c947d600755d98ec41f3a8064ae1d46b0505dd1a3ad2a7800759"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 64-bit (conda)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -276,8 +276,7 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.7"
-  },
-  "orig_nbformat": 4
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -417,12 +417,7 @@ class Hypergraph:
         equivalent to ``for n in H.nodes``.
 
         """
-        nodes = NodeView(self)
-        # Lazy View creation: overload the (class) property on the instance
-        # Then future H.nodes use the existing View
-        # setattr doesn't work because attribute already exists
-        self.__dict__["nodes"] = nodes
-        return nodes
+        return NodeView(self)
 
     def has_node(self, n):
         """Whether the specified node is in the hypergraph.
@@ -784,12 +779,7 @@ class Hypergraph:
             A view of edges in the hypergraph.
 
         """
-        edges = EdgeView(self)
-        # Lazy View creation: overload the (class) property on the instance
-        # Then future H.edges use the existing View
-        # setattr doesn't work because attribute already exists
-        self.__dict__["edges"] = edges
-        return edges
+        return EdgeView(self)
 
     def get_edge_data(self, id, default=None):
         """Get the attributes of an edge.

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -76,15 +76,16 @@ class IDView(Mapping, Set):
     def __init__(self, id_dict, id_attr, ids=None):
         self._id_dict = id_dict
         self._id_attr = id_attr
+
         if id_dict is None:
             self._ids = None
         else:
             if ids is None:
-                self._ids = list(id_dict.keys())
+                self._ids = id_dict.keys()
             else:
                 if not set(ids).issubset(id_dict.keys()):
                     raise XGIError("ids must be a subset of the keys of id_dict")
-                self._ids = list(ids)
+                self._ids = ids
 
     def __len__(self):
         """The number of IDs."""


### PR DESCRIPTION
* accessing `ids` and `id_dict` now by memory instead of making an unnecessary new copy.
* Removed lazy view creation because it decreased the performance of accessing nodes and edges.

Running, for example `[H.edges.members(e) for e in H.edges(e)]` for the [email-enron](https://github.com/ComplexGroupInteractions/xgi-data/blob/main/data/email-Enron/README_email-Enron.md) dataset, the profile before is
![IDView_old](https://user-images.githubusercontent.com/8760347/167515943-bf77fe39-de6b-4e39-93da-03af554ead88.jpg)
and after is
![IDView_new](https://user-images.githubusercontent.com/8760347/167515969-c94e3029-bdd6-4bc0-a790-41967394ef95.jpg)

