### PR TITLE
refactor: put nodes and edges in property decorators

### DIFF
--- a/xgi/algorithms/connected.py
+++ b/xgi/algorithms/connected.py
@@ -1,6 +1,4 @@
 """Algorithms related to connected components of a hypergraph."""
-import random
-
 import xgi
 from xgi.exception import XGIError
 

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -98,10 +98,10 @@ class Hypergraph:
         self._edge = self._hyperedge_dict_factory()
         self._edge_attr = self._hyperedge_attr_dict_factory()
 
-        self.nodes = NodeView(self)
+        self._nodeview = NodeView(self)
         """A :class:`~xgi.classes.reportviews.NodeView` of the hypergraph."""
 
-        self.edges = EdgeView(self)
+        self._edgeview = EdgeView(self)
         """An :class:`~xgi.classes.reportviews.EdgeView` of the hypergraph."""
 
         if incoming_data is not None:
@@ -176,6 +176,14 @@ class Hypergraph:
     def __setitem__(self, attr, val):
         """Write hypergraph attribute."""
         self._hypergraph[attr] = val
+    
+    @property
+    def nodes(self):
+        return self._nodeview
+    
+    @property
+    def edges(self):
+        return self._edgeview
 
     @property
     def num_nodes(self):

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -1,7 +1,7 @@
 """Base class for undirected hypergraphs."""
+from collections.abc import Hashable, Iterable
 from copy import deepcopy
 from warnings import warn
-from collections.abc import Iterable, Hashable
 
 import numpy as np
 
@@ -176,11 +176,11 @@ class Hypergraph:
     def __setitem__(self, attr, val):
         """Write hypergraph attribute."""
         self._hypergraph[attr] = val
-    
+
     @property
     def nodes(self):
         return self._nodeview
-    
+
     @property
     def edges(self):
         return self._edgeview

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -77,8 +77,8 @@ class SimplicialComplex(Hypergraph):
         self._edge = self._hyperedge_dict_factory()
         self._edge_attr = self._hyperedge_attr_dict_factory()
 
-        self.nodes = NodeView(self)
-        self.edges = EdgeView(self)
+        self._nodeview = NodeView(self)
+        self._edgeview = EdgeView(self)
 
         if incoming_data is not None:
             convert.convert_to_simplicial_complex(incoming_data, create_using=self)

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -10,7 +10,7 @@ from itertools import combinations
 
 from xgi import convert
 from xgi.classes import Hypergraph
-from xgi.classes.reportviews import NodeView, EdgeView
+from xgi.classes.reportviews import EdgeView, NodeView
 from xgi.exception import XGIError
 from xgi.utils import XGICounter
 


### PR DESCRIPTION
Moving the node and edge construction to the `Hypergraph` constructor is much faster, but now users can modify nodes and edges by, for example, running `H.nodes = 2`. This PR makes the node/edgeviews protected variables which are accessed through properties.