### PR TITLE
Function to relabel nodes and edges

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,3 +161,11 @@ def hyperwithattrs(edgelist4, attr1, attr2, attr3, attr4, attr5):
         ]
     )
     return H
+
+
+@pytest.fixture
+def hypergraph1():
+    H = xgi.Hypergraph()
+    H.add_nodes_from(["a", "b", "c"])
+    H.add_edges_from({"e1": ["a", "b"], "e2": ["a", "b", "c"], "e3": ["c"]})
+    return H

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,6 @@ def hypergraph1():
 @pytest.fixture
 def hypergraph2():
     H = xgi.Hypergraph()
-    H.add_nodes_from([0, "b", "c"])
+    H.add_nodes_from(["b", "c", 0])
     H.add_edges_from({"e1": [0, "b"], "e2": [0, "c"], "e3": [0, "b", "c"]})
     return H

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,3 +169,11 @@ def hypergraph1():
     H.add_nodes_from(["a", "b", "c"])
     H.add_edges_from({"e1": ["a", "b"], "e2": ["a", "b", "c"], "e3": ["c"]})
     return H
+
+
+@pytest.fixture
+def hypergraph2():
+    H = xgi.Hypergraph()
+    H.add_nodes_from([0, "b", "c"])
+    H.add_edges_from({"e1": [0, "b"], "e2": [0, "c"], "e3": [0, "b", "c"]})
+    return H

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -27,24 +27,44 @@ def test_get_dual(dict5):
     assert dual[8] == [3]
 
 
-def test_convert_labels_to_integers(hypergraph1):
-    H = convert_labels_to_integers(hypergraph1)
+def test_convert_labels_to_integers(hypergraph1, hypergraph2):
+    H1 = convert_labels_to_integers(hypergraph1)
+    H2 = convert_labels_to_integers(hypergraph2)
 
-    assert set(H.nodes) == {0, 1, 2}
-    assert set(H.edges) == {0, 1, 2}
+    assert set(H1.nodes) == {0, 1, 2}
+    assert set(H1.edges) == {0, 1, 2}
 
-    assert H.nodes[0]["label"] == "a"
-    assert H.nodes[1]["label"] == "b"
-    assert H.nodes[2]["label"] == "c"
+    assert H1.nodes[0]["label"] == "a"
+    assert H1.nodes[1]["label"] == "b"
+    assert H1.nodes[2]["label"] == "c"
 
-    assert H.edges[0]["label"] == "e1"
-    assert H.edges[1]["label"] == "e2"
-    assert H.edges[2]["label"] == "e3"
+    assert H1.edges[0]["label"] == "e1"
+    assert H1.edges[1]["label"] == "e2"
+    assert H1.edges[2]["label"] == "e3"
 
-    assert H.edges.members(0) == [0, 1]
-    assert H.edges.members(1) == [0, 1, 2]
-    assert H.edges.members(2) == [2]
+    assert H1.edges.members(0) == [0, 1]
+    assert H1.edges.members(1) == [0, 1, 2]
+    assert H1.edges.members(2) == [2]
 
-    assert H.nodes.memberships(0) == [0, 1]
-    assert H.nodes.memberships(1) == [0, 1]
-    assert H.nodes.memberships(2) == [1, 2]
+    assert H1.nodes.memberships(0) == [0, 1]
+    assert H1.nodes.memberships(1) == [0, 1]
+    assert H1.nodes.memberships(2) == [1, 2]
+
+    assert set(H2.nodes) == {0, 1, 2}
+    assert set(H2.edges) == {0, 1, 2}
+
+    assert H2.nodes[0]["label"] == 0
+    assert H2.nodes[1]["label"] == "b"
+    assert H2.nodes[2]["label"] == "c"
+
+    assert H2.edges[0]["label"] == "e1"
+    assert H2.edges[1]["label"] == "e2"
+    assert H2.edges[2]["label"] == "e3"
+
+    assert H2.edges.members(0) == [0, 1]
+    assert H2.edges.members(1) == [0, 2]
+    assert H2.edges.members(2) == [0, 1, 2]
+
+    assert H2.nodes.memberships(0) == [0, 1, 2]
+    assert H2.nodes.memberships(1) == [0, 2]
+    assert H2.nodes.memberships(2) == [1, 2]

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xgi.utils import get_dual, load_xgi_data
+from xgi.utils import convert_labels_to_integers, get_dual, load_xgi_data
 
 
 @pytest.mark.webtest
@@ -25,3 +25,26 @@ def test_get_dual(dict5):
     assert dual[6] == [2, 3]
     assert dual[7] == [3]
     assert dual[8] == [3]
+
+
+def test_convert_labels_to_integers(hypergraph1):
+    H = convert_labels_to_integers(hypergraph1)
+
+    assert set(H.nodes) == {0, 1, 2}
+    assert set(H.edges) == {0, 1, 2}
+
+    assert H.nodes[0]["label"] == "a"
+    assert H.nodes[1]["label"] == "b"
+    assert H.nodes[2]["label"] == "c"
+
+    assert H.edges[0]["label"] == "e1"
+    assert H.edges[1]["label"] == "e2"
+    assert H.edges[2]["label"] == "e3"
+
+    assert H.edges.members(0) == [0, 1]
+    assert H.edges.members(1) == [0, 1, 2]
+    assert H.edges.members(2) == [2]
+
+    assert H.nodes.memberships(0) == [0, 1]
+    assert H.nodes.memberships(1) == [0, 1]
+    assert H.nodes.memberships(2) == [1, 2]

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -54,21 +54,21 @@ def test_convert_labels_to_integers(hypergraph1, hypergraph2):
     assert set(H2.nodes) == {0, 1, 2}
     assert set(H2.edges) == {0, 1, 2}
 
-    assert H2.nodes[0]["label"] == 0
-    assert H2.nodes[1]["label"] == "b"
-    assert H2.nodes[2]["label"] == "c"
+    assert H2.nodes[0]["label"] == "b"
+    assert H2.nodes[1]["label"] == "c"
+    assert H2.nodes[2]["label"] == 0
 
     assert H2.edges[0]["label"] == "e1"
     assert H2.edges[1]["label"] == "e2"
     assert H2.edges[2]["label"] == "e3"
 
-    assert H2.edges.members(0) == [0, 1]
-    assert H2.edges.members(1) == [0, 2]
-    assert H2.edges.members(2) == [0, 1, 2]
+    assert H2.edges.members(0) == [2, 0]
+    assert H2.edges.members(1) == [2, 1]
+    assert H2.edges.members(2) == [2, 0, 1]
 
-    assert H2.nodes.memberships(0) == [0, 1, 2]
-    assert H2.nodes.memberships(1) == [0, 2]
-    assert H2.nodes.memberships(2) == [1, 2]
+    assert H2.nodes.memberships(0) == [0, 2]
+    assert H2.nodes.memberships(1) == [1, 2]
+    assert H2.nodes.memberships(2) == [0, 1, 2]
 
     assert H3.nodes[0]["old_ids"] == "a"
     assert H3.edges[0]["old_ids"] == "e1"

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -30,6 +30,7 @@ def test_get_dual(dict5):
 def test_convert_labels_to_integers(hypergraph1, hypergraph2):
     H1 = convert_labels_to_integers(hypergraph1)
     H2 = convert_labels_to_integers(hypergraph2)
+    H3 = convert_labels_to_integers(hypergraph1, "old_ids")
 
     assert set(H1.nodes) == {0, 1, 2}
     assert set(H1.edges) == {0, 1, 2}
@@ -68,3 +69,6 @@ def test_convert_labels_to_integers(hypergraph1, hypergraph2):
     assert H2.nodes.memberships(0) == [0, 1, 2]
     assert H2.nodes.memberships(1) == [0, 2]
     assert H2.nodes.memberships(2) == [1, 2]
+
+    assert H3.nodes[0]["old_ids"] == "a"
+    assert H3.edges[0]["old_ids"] == "e1"

--- a/xgi/classes/hypergraphviews.py
+++ b/xgi/classes/hypergraphviews.py
@@ -55,7 +55,7 @@ def subhypergraph(H, nodes=None, edges=None):
     """
     new = H.__class__()
 
-    new._hypergraph = H._hypergraph
+    new._hypergraph = H._hypergraph.copy()
     nodes = set(H.nodes) if nodes is None else (set(nodes) & set(H.nodes))
     edges = set(H.edges) if edges is None else (set(edges) & set(H.edges))
 

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -1,11 +1,10 @@
 """General utilities."""
 from collections import defaultdict
-from cProfile import label
-from itertools import count
 
 import requests
 
 from .. import convert
+from ..classes import Hypergraph
 from ..exception import XGIError
 
 __all__ = ["get_dual", "load_xgi_data", "convert_labels_to_integers"]
@@ -102,21 +101,17 @@ def convert_labels_to_integers(H, label_attribute="label"):
     """
     node_dict = dict(zip(H.nodes, range(H.num_nodes)))
     edge_dict = dict(zip(H.edges, range(H.num_edges)))
-    temp_H = H.copy()
+    temp_H = Hypergraph()
+    temp_H._hypergraph = H._hypergraph.copy()
+
     for node, id in node_dict.items():
-        temp_H._node[id] = temp_H._node.pop(node)
-        temp_H._node_attr[id] = temp_H._node_attr.pop(node)
+        temp_H._node[id] = [edge_dict[e] for e in H._node[node]]
+        temp_H._node_attr[id] = H._node_attr[node].copy()
         temp_H._node_attr[id][label_attribute] = node
 
     for edge, id in edge_dict.items():
-        temp_H._edge[id] = temp_H._edge.pop(edge)
-        temp_H._edge_attr[id] = temp_H._edge_attr.pop(edge)
+        temp_H._edge[id] = [node_dict[n] for n in H._edge[edge]]
+        temp_H._edge_attr[id] = H._edge_attr[edge].copy()
         temp_H._edge_attr[id][label_attribute] = edge
-
-    for node in temp_H.nodes:
-        temp_H._node[node] = [edge_dict[id] for id in temp_H._node[node]]
-
-    for edge in temp_H.edges:
-        temp_H._edge[edge] = [node_dict[id] for id in temp_H._edge[edge]]
 
     return temp_H


### PR DESCRIPTION
This implements a function very similar to `networkx.convert_node_labels_to_integers`. but for both node and edge IDs.