### PR TITLE
Fix drawing

### DIFF
--- a/tests/generators/test_classic.py
+++ b/tests/generators/test_classic.py
@@ -10,8 +10,12 @@ def test_empty_hypergraph():
     assert (H.num_nodes, H.num_edges) == (0, 0)
 
 
-def test_star_clique():
+def test_empty_hypergraph():
+    SC = xgi.empty_simplicial_complex()
+    assert (SC.num_nodes, SC.num_edges) == (0, 0)
 
+
+def test_star_clique():
     with pytest.raises(ValueError):
         H = xgi.star_clique(-1, 7, 3)
     with pytest.raises(ValueError):

--- a/tutorials/Tutorial 5 - Plotting.ipynb
+++ b/tutorials/Tutorial 5 - Plotting.ipynb
@@ -106,13 +106,13 @@
     "cmap = plt.cm.Blues\n",
     "\n",
     "ax = plt.subplot(1,2,1)\n",
-    "xgi.draw(H, pos, cmap=cmap, ax=ax)\n",
+    "xgi.draw(H, pos, edge_fc=cmap, ax=ax)\n",
     "\n",
     "#Qualitative colormap\n",
     "cmap = plt.cm.Set1\n",
     "\n",
     "ax = plt.subplot(1,2,2)\n",
-    "xgi.draw(H, pos, cmap=cmap, ax=ax)"
+    "xgi.draw(H, pos, edge_fc=cmap, ax=ax)"
    ]
   },
   {
@@ -136,9 +136,9 @@
     "node_fc = 'black'\n",
     "node_ec = 'white'\n",
     "node_lw = 2\n",
-    "node_size = 0.07\n",
+    "node_size = 20\n",
     "\n",
-    "xgi.draw(H, pos, cmap=cmap, edge_lc=edge_lc, edge_lw=edge_lw,\n",
+    "xgi.draw(H, pos, edge_fc=cmap, edge_lc=edge_lc, edge_lw=edge_lw,\n",
     "         node_fc=node_fc, node_ec=node_ec, node_lw=node_lw, node_size=node_size)"
    ]
   },
@@ -201,7 +201,7 @@
    "metadata": {},
    "source": [
     "# Example: generative model\n",
-    "We generate and visualize a [Chung-Lu hypergraph](https://doi.org/10.1093/comnet/cnx001)."
+    "We generate and visualize a [random hypergraph](https://doi.org/10.1093/comnet/cnx001)."
    ]
   },
   {
@@ -211,10 +211,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n = 500\n",
-    "k1 = {i : random.randint(10, 30) for i in range(n)}\n",
-    "k2 = {i : sorted(k1.values())[i] for i in range(n)}\n",
-    "H = xgi.chung_lu_hypergraph(k1, k2)"
+    "n = 100\n",
+    "H = xgi.random_hypergraph(100, [0.03, 0.0002, 0.00001])"
    ]
   },
   {
@@ -244,7 +242,39 @@
    "source": [
     "plt.figure(figsize=(10,10))\n",
     "ax = plt.subplot(111)\n",
-    "xgi.draw(H, pos, node_size = 0.01, ax=ax)"
+    "xgi.draw(H, pos, node_size = 5, ax=ax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39e2d438",
+   "metadata": {},
+   "source": [
+    "We can even size the nodes by their degree!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d741e39e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d = H.nodes.degree\n",
+    "s = 5\n",
+    "node_size = {id: np.sqrt((val+1)*s) for id, val in d.asdict().items()}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03902a8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "ax = plt.subplot(111)\n",
+    "xgi.draw(H, pos, node_size = node_size, ax=ax)"
    ]
   },
   {
@@ -277,7 +307,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.4 ('hypergraph')",
    "language": "python",
    "name": "python3"
   },
@@ -291,7 +321,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.9"
+   "version": "3.10.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "fdeb83b6e5b2333358b6ba79181fac315f1a722b4574d7079c134c9ae27f7c53"
+   }
   }
  },
  "nbformat": 4,

--- a/tutorials/Tutorial 5 - Plotting.ipynb
+++ b/tutorials/Tutorial 5 - Plotting.ipynb
@@ -250,7 +250,7 @@
    "id": "39e2d438",
    "metadata": {},
    "source": [
-    "We can even size the nodes by their degree!"
+    "We can even size/color the nodes by their degree!"
    ]
   },
   {
@@ -261,8 +261,11 @@
    "outputs": [],
    "source": [
     "d = H.nodes.degree\n",
-    "s = 5\n",
-    "node_size = {id: np.sqrt((val+1)*s) for id, val in d.asdict().items()}\n"
+    "s = 10\n",
+    "node_size = {id: np.sqrt((val+1)*s) for id, val in d.asdict().items()}\n",
+    "c = plt.cm.Blues\n",
+    "cmap = [c(i) for i in np.linspace(0.1, 0.9, d.max() + 1)]\n",
+    "node_fc = {id: np.array(cmap[val]) for id, val in d.asdict().items()}\n"
    ]
   },
   {
@@ -272,9 +275,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from matplotlib.axes._axes import _log as matplotlib_axes_logger\n",
+    "matplotlib_axes_logger.setLevel('ERROR')\n",
     "plt.figure(figsize=(10,10))\n",
     "ax = plt.subplot(111)\n",
-    "xgi.draw(H, pos, node_size = node_size, ax=ax)"
+    "xgi.draw(H, pos, node_size = node_size, node_fc=node_fc, ax=ax)"
    ]
   },
   {

--- a/tutorials/Tutorial 5 - Plotting.ipynb
+++ b/tutorials/Tutorial 5 - Plotting.ipynb
@@ -265,7 +265,7 @@
     "node_size = {id: np.sqrt((val+1)*s) for id, val in d.asdict().items()}\n",
     "c = plt.cm.Blues\n",
     "cmap = [c(i) for i in np.linspace(0.1, 0.9, d.max() + 1)]\n",
-    "node_fc = {id: np.array(cmap[val]) for id, val in d.asdict().items()}\n"
+    "node_fc = {id: np.array(cmap[val]).reshape(1, -1) for id, val in d.asdict().items()}"
    ]
   },
   {
@@ -275,8 +275,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib.axes._axes import _log as matplotlib_axes_logger\n",
-    "matplotlib_axes_logger.setLevel('ERROR')\n",
     "plt.figure(figsize=(10,10))\n",
     "ax = plt.subplot(111)\n",
     "xgi.draw(H, pos, node_size = node_size, node_fc=node_fc, ax=ax)"

--- a/xgi/drawing/layout.py
+++ b/xgi/drawing/layout.py
@@ -231,7 +231,7 @@ def weighted_barycenter_spring_layout(H, return_phantom_graph=False):
     except ValueError:
         # The list of node-labels has no integers, so I start from 0
         phantom_node_id = 0
-    
+
     # Looping over the hyperedges of different order (from triples up)
     for d in range(2, max_edge_order(H) + 1):
         # Hyperedges of order d (d=2: triplets, etc.)

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -108,13 +108,14 @@ def draw(
     else:
         raise XGIError("The input must be a SimplicialComplex or Hypergraph")
 
-    draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_size, node_lw, d_max)
+    draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_lw, node_size, d_max)
 
 
-def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_size, node_lw, zorder):
+def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_lw, node_size, zorder):
     # Note Iterable covers lists, tuples, ranges, generators, np.ndarrays, etc
     node_fc = _arg_to_dict(node_fc, H.nodes)
     node_ec = _arg_to_dict(node_ec, H.nodes)
+    node_lw = _arg_to_dict(node_lw, H.nodes)
     node_size = _arg_to_dict(node_size, H.nodes)
 
     for i in H.nodes:

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -112,6 +112,27 @@ def draw(
 
 
 def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_lw, node_size, zorder):
+    """Draw the nodes of a hypergraph
+
+    Parameters
+    ----------
+    ax : axis handle
+        Plot axes on which to draw the visualization
+    H : Hypergraph or SimplicialComplex
+        Higher-order network to plot
+    pos : dict of lists
+        the x, y position of every node
+    node_fc : str, 4-tuple, or dict of strings or 4-tuples
+        the color of the nodes
+    node_ec : str, 4-tuple, or dict of strings or 4-tuples
+        the outline color of the nodes
+    node_lw : int, float, or dict of ints or floats
+        the line weight of the outline of the nodes
+    node_size : int, float, or dict of ints or floats
+        the node radius
+    zorder : int
+        the layer on which to draw the nodes
+    """
     # Note Iterable covers lists, tuples, ranges, generators, np.ndarrays, etc
     node_fc = _arg_to_dict(node_fc, H.nodes)
     node_ec = _arg_to_dict(node_ec, H.nodes)
@@ -132,6 +153,23 @@ def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_lw, node_size, zorder):
 
 
 def draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max):
+    """ Draw hyperedges.
+
+    Parameters
+    ----------
+    ax : axis handle
+        figure axes to plot onto
+    H : Hypergraph
+        A hypergraph
+    pos : dict of lists
+        x,y position of every node
+    edge_lc : str, 4-tuple, or dict of 4-tuples or strings
+        the color of the pairwise edges
+    edge_lw : int, float, or dict
+        pairwise edge widths
+    edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
+        color of hyperedges
+    """
     edge_lc = _arg_to_dict(edge_lc, H.edges)
     edge_lw = _arg_to_dict(edge_lw, H.edges)
 
@@ -167,12 +205,29 @@ def draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max):
             ax.add_patch(obj)
 
 
-def draw_xgi_complexes(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max):
-    # I will only plot the maximal simplices, so I convert the SC to H
-    H_ = convert.from_simplicial_complex_to_hypergraph(H)
+def draw_xgi_complexes(ax, SC, pos, edge_lc, edge_lw, edge_fc):
+    """ Draw maximal simplices and pairwise faces.
 
-    edge_lc = _arg_to_dict(edge_lc, H.edges)
-    edge_fc = _color_edges(edge_fc, H.edges)
+    Parameters
+    ----------
+    ax : axis handle
+        figure axes to plot onto
+    SC : SimplicialComplex
+        A simpicial comples
+    pos : dict of lists
+        x,y position of every node
+    edge_lc : str, 4-tuple, or dict of 4-tuples or strings
+        the color of the pairwise edges
+    edge_lw : int, float, or dict
+        pairwise edge widths
+    edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
+        color of simplices
+    """
+    # I will only plot the maximal simplices, so I convert the SC to H
+    H_ = convert.from_simplicial_complex_to_hypergraph(SC)
+
+    edge_lc = _arg_to_dict(edge_lc, SC.edges)
+    edge_fc = _color_edges(edge_fc, SC.edges)
     # Looping over the hyperedges of different order (reversed) -- nodes will be plotted separately
     for id, he in H_.edges.members(dtype=dict).items():
         d = len(he) - 1
@@ -244,8 +299,8 @@ def _color_edges(colors, H):
     ----------
     colors : str, dict, cmap, or iterable
         attributes for drawing parameter
-    ids : NodeView or EdgeView
-        This is the node or edge IDs that attributes get mapped to.
+    H : Hypergraph
+        Hypergraph to color
 
     Returns
     -------

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -33,8 +33,8 @@ def draw(
     edge_lw=1.5,
     node_fc="white",
     node_ec="black",
-    node_lw=1,
-    node_size=0.03,
+    node_lw=100,
+    node_size=3,
 ):
     """Draw hypergraph or simplicial complex.
 
@@ -129,18 +129,18 @@ def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_size, node_lw, zorder):
     node_ec = _arg_to_dict(node_ec, H.nodes)
     node_size = _arg_to_dict(node_size, H.nodes)
 
-    # Drawing the nodes
     for i in list(H.nodes):
         (x, y) = pos[i]
-        circ = plt.Circle(
-            [x, y],
-            radius=node_size[i],
-            lw=node_lw,
+        ax.scatter(
+            x,
+            y,
+            s=node_size[i],
+            c=node_fc[i],
+            edgecolors=node_ec[i],
+            linewidths=node_lw,
             zorder=zorder,
-            ec=node_ec[i],
-            fc=node_fc[i],
         )
-        ax.add_patch(circ)
+        
 
 
 def draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, d_max, colors):

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -153,7 +153,7 @@ def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_lw, node_size, zorder):
 
 
 def draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max):
-    """ Draw hyperedges.
+    """Draw hyperedges.
 
     Parameters
     ----------
@@ -206,7 +206,7 @@ def draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max):
 
 
 def draw_xgi_complexes(ax, SC, pos, edge_lc, edge_lw, edge_fc):
-    """ Draw maximal simplices and pairwise faces.
+    """Draw maximal simplices and pairwise faces.
 
     Parameters
     ----------

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -31,10 +31,11 @@ def draw(
     ax=None,
     edge_lc="black",
     edge_lw=1.5,
+    edge_fc=None,
     node_fc="white",
     node_ec="black",
-    node_lw=100,
-    node_size=3,
+    node_lw=1,
+    node_size=10,
 ):
     """Draw hypergraph or simplicial complex.
 
@@ -72,10 +73,10 @@ def draw(
     specified in the same order as the nodes are found in H.nodes.
 
     node_lw : float (default=1.0)
-    Line width of the node borders.
+    Line width of the node borders in pixels.
 
     node_size : float (default=0.03)
-    Size of the nodes.
+    Radius of the nodes in pixels
 
     Examples
     --------
@@ -89,20 +90,6 @@ def draw(
     if pos is None:
         pos = barycenter_spring_layout(H)
 
-    # Defining colors, one for each dimension
-    d_max = max_edge_order(H)
-    if cmap is None:
-        cmap = cm.Paired
-        colors = [cmap(i) for i in range(0, d_max + 1)]
-    else:
-        if type(cmap) == ListedColormap:
-            # The colormap is already discrete
-            colors = [cmap(i) for i in range(0, d_max + 1)]
-        elif type(cmap) == LinearSegmentedColormap:
-            # I need to discretize the given colormap
-            color_range = np.linspace(0.1, 0.9, d_max)
-            colors = [cmap(i) for i in color_range]
-
     if ax is None:
         ax = plt.gca()
     ax.set_xlim([-1.1, 1.1])
@@ -111,16 +98,17 @@ def draw(
     ax.get_yaxis().set_ticks([])
     ax.axis("off")
 
+    d_max = max_edge_order(H)
+
     if isinstance(H, Hypergraph):
-        draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, d_max, colors)
+        draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max)
 
     elif isinstance(H, SimplicialComplex):
-        # I will only plot the maximal simplices, so I convert the SC to H
-        draw_xgi_complexes(ax, H, pos, edge_lc, edge_lw, d_max, colors)
+        draw_xgi_complexes(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max)
     else:
         raise XGIError("The input must be a SimplicialComplex or Hypergraph")
 
-    draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_size, node_lw, d_max + 1)
+    draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_size, node_lw, d_max)
 
 
 def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_size, node_lw, zorder):
@@ -134,82 +122,86 @@ def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_size, node_lw, zorder):
         ax.scatter(
             x,
             y,
-            s=node_size[i],
+            s=node_size[i] ** 2,
             c=node_fc[i],
             edgecolors=node_ec[i],
             linewidths=node_lw,
             zorder=zorder,
         )
-        
 
 
-def draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, d_max, colors):
+def draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max):
     edge_lc = _arg_to_dict(edge_lc, H.edges)
+    edge_lw = _arg_to_dict(edge_lw, H.edges)
+
+    edge_fc = _color_edges(edge_fc, H)
     # Looping over the hyperedges of different order (reversed) -- nodes will be plotted separately
-    for d in reversed(range(1, d_max + 1)):
+
+    for id, he in H.edges.members(dtype=dict).items():
+        d = len(he) - 1
         if d == 1:
             # Drawing the edges
-            for idx, he in H.edges.filterby("order", d).members(dtype=dict).items():
-                he = list(he)
-                x_coords = [pos[he[0]][0], pos[he[1]][0]]
-                y_coords = [pos[he[0]][1], pos[he[1]][1]]
-                line = plt.Line2D(x_coords, y_coords, color=edge_lc[idx], lw=edge_lw)
-                ax.add_line(line)
+            he = list(he)
+            x_coords = [pos[he[0]][0], pos[he[1]][0]]
+            y_coords = [pos[he[0]][1], pos[he[1]][1]]
+            line = plt.Line2D(
+                x_coords, y_coords, color=edge_lc[id], lw=edge_lw[id], zorder=d_max - 1
+            )
+            ax.add_line(line)
 
         else:
             # Hyperedges of order d (d=1: links, etc.)
-            for idx, he in H.edges.filterby("order", d).members(dtype=dict).items():
-                # Filling the polygon
-                coordinates = [[pos[n][0], pos[n][1]] for n in he]
-                # Sorting the points counterclockwise (needed to have the correct filling)
-                sorted_coordinates = _CCW_sort(coordinates)
-                obj = plt.Polygon(
-                    sorted_coordinates,
-                    edgecolor=edge_lc[idx],
-                    facecolor=colors[d - 1],
-                    alpha=0.4,
-                    lw=0.5,
-                )
-                ax.add_patch(obj)
+            # Filling the polygon
+            coordinates = [[pos[n][0], pos[n][1]] for n in he]
+            # Sorting the points counterclockwise (needed to have the correct filling)
+            sorted_coordinates = _CCW_sort(coordinates)
+            obj = plt.Polygon(
+                sorted_coordinates,
+                edgecolor=edge_lc[id],
+                facecolor=edge_fc[id],
+                alpha=0.4,
+                lw=0.5,
+                zorder=d_max - d,
+            )
+            ax.add_patch(obj)
 
 
-def draw_xgi_complexes(ax, H, pos, edge_lc, edge_lw, colors, d_max):
+def draw_xgi_complexes(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max):
+    # I will only plot the maximal simplices, so I convert the SC to H
     H_ = convert.from_simplicial_complex_to_hypergraph(H)
 
     edge_lc = _arg_to_dict(edge_lc, H.edges)
+    edge_fc = _color_edges(edge_fc, H.edges)
     # Looping over the hyperedges of different order (reversed) -- nodes will be plotted separately
-    for d in reversed(range(1, d_max + 1)):
+    for id, he in H_.edges.members(dtype=dict).items():
+        d = len(he) - 1
         if d == 1:
             # Drawing the edges
-            for idx, he in H_.edges.filterby("order", d).members(dtype=dict).items():
-                he = list(he)
-                x_coords = [pos[he[0]][0], pos[he[1]][0]]
-                y_coords = [pos[he[0]][1], pos[he[1]][1]]
-                line = plt.Line2D(x_coords, y_coords, color=edge_lc[idx], lw=edge_lw)
-                ax.add_line(line)
+            he = list(he)
+            x_coords = [pos[he[0]][0], pos[he[1]][0]]
+            y_coords = [pos[he[0]][1], pos[he[1]][1]]
+            line = plt.Line2D(x_coords, y_coords, color=edge_lc[id], lw=edge_lw)
+            ax.add_line(line)
         else:
             # Hyperedges of order d (d=1: links, etc.)
-            for idx, he in H_.edges.filterby("order", d).members(dtype=dict).items():
-                # Filling the polygon
-                coordinates = [[pos[n][0], pos[n][1]] for n in he]
-                # Sorting the points counterclockwise (needed to have the correct filling)
-                sorted_coordinates = _CCW_sort(coordinates)
-                obj = plt.Polygon(
-                    sorted_coordinates,
-                    edgecolor=edge_lc[idx],
-                    facecolor=colors[d - 1],
-                    alpha=0.4,
-                    lw=0.5,
-                )
-                ax.add_patch(obj)
-                # Drawing the all the edges within
-                for i, j in combinations(sorted_coordinates, 2):
-                    x_coords = [i[0], j[0]]
-                    y_coords = [i[1], j[1]]
-                    line = plt.Line2D(
-                        x_coords, y_coords, color=edge_lc[idx], lw=edge_lw
-                    )
-                    ax.add_line(line)
+            # Filling the polygon
+            coordinates = [[pos[n][0], pos[n][1]] for n in he]
+            # Sorting the points counterclockwise (needed to have the correct filling)
+            sorted_coordinates = _CCW_sort(coordinates)
+            obj = plt.Polygon(
+                sorted_coordinates,
+                edgecolor=edge_lc[id],
+                facecolor=edge_fc[id],
+                alpha=0.4,
+                lw=0.5,
+            )
+            ax.add_patch(obj)
+            # Drawing the all the edges within
+            for i, j in combinations(sorted_coordinates, 2):
+                x_coords = [i[0], j[0]]
+                y_coords = [i[1], j[1]]
+                line = plt.Line2D(x_coords, y_coords, color=edge_lc[id], lw=edge_lw[id])
+                ax.add_line(line)
 
 
 def _arg_to_dict(arg, ids):
@@ -242,6 +234,46 @@ def _arg_to_dict(arg, ids):
         raise TypeError(
             f"argument must be dict, str, or iterable, received {type(arg)}"
         )
+
+
+def _color_edges(colors, H):
+    """Map different types of arguments for drawing style to a dict.
+
+    Parameters
+    ----------
+    colors : str, dict, cmap, or iterable
+        attributes for drawing parameter
+    ids : NodeView or EdgeView
+        This is the node or edge IDs that attributes get mapped to.
+
+    Returns
+    -------
+    dict
+        an ID: attribute dictionary
+
+    Raises
+    ------
+    TypeError
+        if a string, list, or dict is not passed
+    """
+    # Defining colors, one for each dimension
+    d_max = max_edge_order(H)
+    if colors is None:
+        colors = cm.Paired
+
+    if type(colors) == ListedColormap:
+        # The colormap is already discrete
+        c = [colors(i) for i in range(d_max)]
+        order = H.edges.order.asdict()
+        return {e: c[order[e] - 1] for e in H.edges}
+    elif type(colors) == LinearSegmentedColormap:
+        # I need to discretize the given colormap
+        color_range = np.linspace(0.1, 0.9, d_max)
+        c = [colors(i) for i in color_range]
+        order = H.edges.order.asdict()
+        return {e: c[order[e] - 1] for e in H.edges}
+    else:
+        return _arg_to_dict(colors, H.edges)
 
 
 def _CCW_sort(p):

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -226,7 +226,7 @@ def _arg_to_dict(arg, ids):
         if a string, list, or dict is not passed
     """
     if isinstance(arg, dict):
-        return {id: arg[id] for id in arg if arg in ids}
+        return {id: arg[id] for id in arg if id in ids}
     if type(arg) in [int, float, str]:
         return {id: arg for id in ids}
     elif isinstance(arg, Iterable):

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -117,7 +117,7 @@ def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_size, node_lw, zorder):
     node_ec = _arg_to_dict(node_ec, H.nodes)
     node_size = _arg_to_dict(node_size, H.nodes)
 
-    for i in list(H.nodes):
+    for i in H.nodes:
         (x, y) = pos[i]
         ax.scatter(
             x,
@@ -125,7 +125,7 @@ def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_size, node_lw, zorder):
             s=node_size[i] ** 2,
             c=node_fc[i],
             edgecolors=node_ec[i],
-            linewidths=node_lw,
+            linewidths=node_lw[i],
             zorder=zorder,
         )
 
@@ -225,7 +225,7 @@ def _arg_to_dict(arg, ids):
         if a string, list, or dict is not passed
     """
     if isinstance(arg, dict):
-        return arg
+        return {id: arg[id] for id in arg if arg in ids}
     if type(arg) in [int, float, str]:
         return {id: arg for id in ids}
     elif isinstance(arg, Iterable):


### PR DESCRIPTION
This fixes #137 and #140. Among other things, user can specify
* node size, node line color, node face color, node line width, edge line width, and edge color as dictionaries, iterables, or strings.
* edge face color as a colormap, dictionary, iterable or string.

The `draw` function is now modularized into `draw_xgi_nodes`, `draw_xgi_hyperedges`, and `draw_xgi_complexes` as well as a few helper functions. In addition, nodes are now drawn with `scatter` not `Circle` objects.