### PR TITLE
Added ability to draw NodeStats and EdgeStats

### DIFF
--- a/tutorials/Tutorial 5 - Plotting.ipynb
+++ b/tutorials/Tutorial 5 - Plotting.ipynb
@@ -90,7 +90,7 @@
    "id": "7895f303",
    "metadata": {},
    "source": [
-    "**Colors of the hyperedges** are designed to match the hyperedge size. Both sequential and qualitative [colormaps](https://matplotlib.org/stable/tutorials/colors/colormaps.html) can be passed as an argument. Sequential colormaps would simply be discretized according to the sizes of the provided hypergraph:"
+    "**Colors of the hyperedges** match the hyperedge size by default, but any statistic can be used to color it as well. The default colormap can be changed by updating the default arguments. Both sequential and qualitative [colormaps](https://matplotlib.org/stable/tutorials/colors/colormaps.html) can be passed as an argument. Sequential colormaps would simply be discretized according to the sizes of the provided hypergraph:"
    ]
   },
   {
@@ -103,16 +103,16 @@
     "plt.figure(figsize=(10,4))\n",
     "\n",
     "#Sequential colormap\n",
-    "cmap = plt.cm.Blues\n",
+    "cmap = plt.cm.Paired\n",
     "\n",
     "ax = plt.subplot(1,2,1)\n",
-    "xgi.draw(H, pos, edge_fc=cmap, ax=ax)\n",
+    "xgi.draw(H, pos, ax=ax, edge_face_colormap=cmap)\n",
     "\n",
     "#Qualitative colormap\n",
-    "cmap = plt.cm.Set1\n",
+    "cmap = plt.cm.Purples\n",
     "\n",
     "ax = plt.subplot(1,2,2)\n",
-    "xgi.draw(H, pos, edge_fc=cmap, ax=ax)"
+    "xgi.draw(H, pos, ax=ax, edge_face_colormap=cmap)"
    ]
   },
   {
@@ -138,8 +138,8 @@
     "node_lw = 2\n",
     "node_size = 20\n",
     "\n",
-    "xgi.draw(H, pos, edge_fc=cmap, edge_lc=edge_lc, edge_lw=edge_lw,\n",
-    "         node_fc=node_fc, node_ec=node_ec, node_lw=node_lw, node_size=node_size)"
+    "xgi.draw(H, pos, edge_lc=edge_lc, edge_lw=edge_lw,\n",
+    "         node_fc=node_fc, node_ec=node_ec, node_lw=node_lw, node_size=node_size, edge_face_colormap=cmap)"
    ]
   },
   {
@@ -212,16 +212,7 @@
    "outputs": [],
    "source": [
     "n = 100\n",
-    "H = xgi.random_hypergraph(100, [0.03, 0.0002, 0.00001])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a787a43d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "H = xgi.random_hypergraph(100, [0.03, 0.0002, 0.00001])\n",
     "pos = xgi.barycenter_spring_layout(H)"
    ]
   },
@@ -242,7 +233,7 @@
    "source": [
     "plt.figure(figsize=(10,10))\n",
     "ax = plt.subplot(111)\n",
-    "xgi.draw(H, pos, node_size = 5, ax=ax)"
+    "xgi.draw(H, pos, node_size = 10, ax=ax)"
    ]
   },
   {
@@ -277,7 +268,7 @@
    "source": [
     "plt.figure(figsize=(10,10))\n",
     "ax = plt.subplot(111)\n",
-    "xgi.draw(H, pos, node_size = node_size, node_fc=node_fc, ax=ax)"
+    "xgi.draw(H, pos, node_size = H.nodes.degree, node_lw = H.nodes.degree, node_fc=H.nodes.cec_centrality, edge_fc=H.edges.node_edge_centrality, ax=ax)"
    ]
   },
   {

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -36,7 +36,7 @@ def CEC_centrality(H, tol=1e-6):
     """
     W, node_dict = clique_motif_matrix(H, index=True)
     _, v = eigsh(W.asfptype(), k=1, which="LM", tol=tol)
-    return {node_dict[n]: v[n] for n in node_dict}
+    return {node_dict[n]: v[n].item() for n in node_dict}
 
 
 def ZEC_centrality(H, max_iter=100, tol=1e-6):

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -56,32 +56,45 @@ def draw(
     ax : matplotlib.pyplot.axes (default=None)
 
     edge_lc : color (str, dict, or iterable, default='black')
-    Color of the edges (dyadic links and borders of the hyperedges).  If str, use the
-    same color for all edges.  If a dict, must contain (edge_id: color_str) pairs.  If
-    iterable, assume the colors are specified in the same order as the edges are found
-    in H.edges.
+        Color of the edges (dyadic links and borders of the hyperedges).  If str, use the
+        same color for all edges.  If a dict, must contain (edge_id: color_str) pairs.  If
+        iterable, assume the colors are specified in the same order as the edges are found
+        in H.edges.
 
     edge_lw :  float (default=1.5)
-    Line width of edges of order 1 (dyadic links).
+        Line width of edges of order 1 (dyadic links).
 
     edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
-    Color of hyperedges
+        Color of hyperedges
 
     node_fc : color (str, dict, or iterable, default='white')
-    Color of the nodes.  If str, use the same color for all nodes.  If a dict, must
-    contain (node_id: color_str) pairs.  If other iterable, assume the colors are
-    specified in the same order as the nodes are found in H.nodes.
+        Color of the nodes.  If str, use the same color for all nodes.  If a dict, must
+        contain (node_id: color_str) pairs.  If other iterable, assume the colors are
+        specified in the same order as the nodes are found in H.nodes.
 
     node_ec : color (dict or str, default='black')
-    Color of node borders.  If str, use the same color for all nodes.  If a dict, must
-    contain (node_id: color_str) pairs.  If other iterable, assume the colors are
-    specified in the same order as the nodes are found in H.nodes.
+        Color of node borders.  If str, use the same color for all nodes.  If a dict, must
+        contain (node_id: color_str) pairs.  If other iterable, assume the colors are
+        specified in the same order as the nodes are found in H.nodes.
 
     node_lw : float (default=1.0)
-    Line width of the node borders in pixels.
+        Line width of the node borders in pixels.
 
     node_size : float (default=0.03)
-    Radius of the nodes in pixels
+        Radius of the nodes in pixels
+
+    **kwargs : optional args
+        alternate default values. Values that can be overwritten are the following:
+        * min_node_size
+        * max_node_size
+        * min_edge_linewidth
+        * max_edge_linewidth
+        * min_node_linewidth
+        * max_node_linewidth
+        * node_colormap
+        * node_outline_colormap
+        * edge_face_colormap
+        * edge_outline_colormap
 
     Examples
     --------
@@ -154,12 +167,18 @@ def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_lw, node_size, zorder, set
         The node radius
     zorder : int
         The layer on which to draw the nodes
+    settings : dict
+        Default parameters
     """
     # Note Iterable covers lists, tuples, ranges, generators, np.ndarrays, etc
     node_fc = _color_arg_to_dict(node_fc, H.nodes, settings["node_colormap"])
     node_ec = _color_arg_to_dict(node_ec, H.nodes, settings["node_outline_colormap"])
-    node_lw = _scalar_arg_to_dict(node_lw, H.nodes, settings["min_node_linewidth"], settings["max_node_linewidth"])
-    node_size = _scalar_arg_to_dict(node_size, H.nodes, settings["min_node_size"], settings["max_node_size"])
+    node_lw = _scalar_arg_to_dict(
+        node_lw, H.nodes, settings["min_node_linewidth"], settings["max_node_linewidth"]
+    )
+    node_size = _scalar_arg_to_dict(
+        node_size, H.nodes, settings["min_node_size"], settings["max_node_size"]
+    )
 
     for i in H.nodes:
         (x, y) = pos[i]
@@ -191,9 +210,13 @@ def draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max, settings):
         Pairwise edge widths
     edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
         Color of hyperedges
+    settings : dict
+        Default parameters
     """
     edge_lc = _color_arg_to_dict(edge_lc, H.edges, settings["edge_outline_colormap"])
-    edge_lw = _scalar_arg_to_dict(edge_lw, H.edges, settings["min_edge_linewidth"], settings["max_edge_linewidth"])
+    edge_lw = _scalar_arg_to_dict(
+        edge_lw, H.edges, settings["min_edge_linewidth"], settings["max_edge_linewidth"]
+    )
 
     edge_fc = _color_arg_to_dict(edge_fc, H.edges, settings["edge_face_colormap"])
     # Looping over the hyperedges of different order (reversed) -- nodes will be plotted separately
@@ -244,12 +267,19 @@ def draw_xgi_complexes(ax, SC, pos, edge_lc, edge_lw, edge_fc, settings):
         Pairwise edge widths
     edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
         Color of simplices
+    settings : dict
+        Default parameters
     """
     # I will only plot the maximal simplices, so I convert the SC to H
     H_ = convert.from_simplicial_complex_to_hypergraph(SC)
 
     edge_lc = _color_arg_to_dict(edge_lc, H_.edges, settings["edge_outline_colormap"])
-    edge_lw = _scalar_arg_to_dict(edge_lw, H_.edges, settings["min_edge_linewidth"], settings["max_edge_linewidth"])
+    edge_lw = _scalar_arg_to_dict(
+        edge_lw,
+        H_.edges,
+        settings["min_edge_linewidth"],
+        settings["max_edge_linewidth"],
+    )
 
     edge_fc = _color_arg_to_dict(edge_fc, H_.edges, settings["edge_face_colormap"])
     # Looping over the hyperedges of different order (reversed) -- nodes will be plotted separately
@@ -289,10 +319,14 @@ def _scalar_arg_to_dict(arg, ids, min_val, max_val):
 
     Parameters
     ----------
-    arg : str, dict, or iterable
+    arg : int, float, dict, iterable, or NodeStat/EdgeStat
         Attributes for drawing parameter
     ids : NodeView or EdgeView
         This is the node or edge IDs that attributes get mapped to.
+    min_val : int or float
+        The minimum value of the drawing parameter
+    max_val : int or float
+        The maximum value of the drawing parameter
 
     Returns
     -------
@@ -302,7 +336,7 @@ def _scalar_arg_to_dict(arg, ids, min_val, max_val):
     Raises
     ------
     TypeError
-        If a string, list, or dict is not passed
+        If a int, float, list, dict, or NodeStat/EdgeStat is not passed
     """
     if isinstance(arg, dict):
         return {id: arg[id] for id in arg if id in ids}
@@ -325,10 +359,12 @@ def _color_arg_to_dict(arg, ids, cmap):
 
     Parameters
     ----------
-    arg : str, dict, or iterable
+    arg : str, dict, iterable, or NodeStat/EdgeStat
         Attributes for drawing parameter
     ids : NodeView or EdgeView
         This is the node or edge IDs that attributes get mapped to.
+    cmap : ListedColormap or LinearSegmentedColormap
+        colormap to use for NodeStat/EdgeStat
 
     Returns
     -------
@@ -338,7 +374,7 @@ def _color_arg_to_dict(arg, ids, cmap):
     Raises
     ------
     TypeError
-        If a string, list, or dict is not passed
+        If a string, tuple, list, or dict is not passed
     """
     if isinstance(arg, dict):
         return {id: arg[id] for id in arg if id in ids}
@@ -359,6 +395,7 @@ def _color_arg_to_dict(arg, ids, cmap):
         raise TypeError(
             f"argument must be dict, str, or iterable, received {type(arg)}"
         )
+
 
 def _CCW_sort(p):
     """

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -388,7 +388,7 @@ def _color_arg_to_dict(arg, ids, cmap):
         else:
             raise XGIError("Invalid colormap!")
         s = arg.asdict()
-        return {id: cmap(f(s[id])) for id in ids}
+        return {id: np.array(cmap(f(s[id]))).reshape(1, -1) for id in ids}
     elif isinstance(arg, Iterable):
         return {id: arg[idx] for idx, id in enumerate(ids)}
     else:

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -29,12 +29,12 @@ def draw(
     H,
     pos=None,
     ax=None,
-    edge_lc="black",
-    edge_lw=1.5,
-    edge_fc=None,
-    node_fc="white",
-    node_ec="black",
-    node_lw=1,
+    link_color="black",
+    link_width=1.5,
+    edge_facecolor=None,
+    node_facecolor="white",
+    node_edgecolor="black",
+    node_edgewidth=1,
     node_size=10,
     **kwargs,
 ):
@@ -50,29 +50,29 @@ def draw(
 
     ax : matplotlib.pyplot.axes (default=None)
 
-    edge_lc : color (str, dict, or iterable, default='black')
-        Color of the edges (dyadic links and borders of the hyperedges).  If str, use the
+    link_color : color (str, dict, or iterable, default='black')
+        Color of the dyadic links.  If str, use the
         same color for all edges.  If a dict, must contain (edge_id: color_str) pairs.  If
         iterable, assume the colors are specified in the same order as the edges are found
         in H.edges.
 
-    edge_lw :  float (default=1.5)
+    link_width :  float (default=1.5)
         Line width of edges of order 1 (dyadic links).
 
-    edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
+    edge_facecolor : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
         Color of hyperedges
 
-    node_fc : color (str, dict, or iterable, default='white')
+    node_facecolor : color (str, dict, or iterable, default='white')
         Color of the nodes.  If str, use the same color for all nodes.  If a dict, must
         contain (node_id: color_str) pairs.  If other iterable, assume the colors are
         specified in the same order as the nodes are found in H.nodes.
 
-    node_ec : color (dict or str, default='black')
+    node_edgecolor : color (dict or str, default='black')
         Color of node borders.  If str, use the same color for all nodes.  If a dict, must
         contain (node_id: color_str) pairs.  If other iterable, assume the colors are
         specified in the same order as the nodes are found in H.nodes.
 
-    node_lw : float (default=1.0)
+    node_edgewidth : float (default=1.0)
         Line width of the node borders in pixels.
 
     node_size : float (default=0.03)
@@ -82,14 +82,14 @@ def draw(
         alternate default values. Values that can be overwritten are the following:
         * min_node_size
         * max_node_size
-        * min_edge_lw
-        * max_edge_lw
-        * min_node_lw
-        * max_node_lw
-        * node_fc_colormap
-        * node_lc_colormap
-        * edge_fc_colormap
-        * edge_lc_colormap
+        * min_link_width
+        * max_link_width
+        * min_node_edgewidth
+        * max_node_edgewidth
+        * node_facecolor_cmap
+        * node_lc_cmap
+        * edge_facecolor_cmap
+        * link_color_cmap
 
     Examples
     --------
@@ -102,20 +102,20 @@ def draw(
     settings = {
         "min_node_size": 10,
         "max_node_size": 30,
-        "min_edge_lw": 2,
-        "max_edge_lw": 10,
-        "min_node_lw": 1,
-        "max_node_lw": 5,
-        "node_fc_colormap": cm.Reds,
-        "node_lc_colormap": cm.Greys,
-        "edge_fc_colormap": cm.Blues,
-        "edge_lc_colormap": cm.Greys,
+        "min_link_width": 2,
+        "max_link_width": 10,
+        "min_node_edgewidth": 1,
+        "max_node_edgewidth": 5,
+        "node_facecolor_cmap": cm.Reds,
+        "node_lc_cmap": cm.Greys,
+        "edge_facecolor_cmap": cm.Blues,
+        "link_color_cmap": cm.Greys,
     }
 
     settings.update(kwargs)
 
-    if edge_fc is None:
-        edge_fc = H.edges.size
+    if edge_facecolor is None:
+        edge_facecolor = H.edges.size
 
     if pos is None:
         pos = barycenter_spring_layout(H)
@@ -131,16 +131,38 @@ def draw(
     d_max = max_edge_order(H)
 
     if isinstance(H, SimplicialComplex):
-        draw_xgi_simplices(H, pos, ax, edge_lc, edge_lw, edge_fc, settings)
+        draw_xgi_simplices(H, pos, ax, link_color, link_width, edge_facecolor, settings)
     elif isinstance(H, Hypergraph):
-        draw_xgi_hyperedges(H, pos, ax, edge_lc, edge_lw, edge_fc, d_max, settings)
+        draw_xgi_hyperedges(
+            H, pos, ax, link_color, link_width, edge_facecolor, d_max, settings
+        )
     else:
         raise XGIError("The input must be a SimplicialComplex or Hypergraph")
 
-    draw_xgi_nodes(H, pos, ax, node_fc, node_ec, node_lw, node_size, d_max, settings)
+    draw_xgi_nodes(
+        H,
+        pos,
+        ax,
+        node_facecolor,
+        node_edgecolor,
+        node_edgewidth,
+        node_size,
+        d_max,
+        settings,
+    )
 
 
-def draw_xgi_nodes(H, pos, ax, node_fc, node_ec, node_lw, node_size, zorder, settings):
+def draw_xgi_nodes(
+    H,
+    pos,
+    ax,
+    node_facecolor,
+    node_edgecolor,
+    node_edgewidth,
+    node_size,
+    zorder,
+    settings,
+):
     """Draw the nodes of a hypergraph
 
     Parameters
@@ -151,11 +173,11 @@ def draw_xgi_nodes(H, pos, ax, node_fc, node_ec, node_lw, node_size, zorder, set
         Higher-order network to plot
     pos : dict of lists
         The x, y position of every node
-    node_fc : str, 4-tuple, or dict of strings or 4-tuples
+    node_facecolor : str, 4-tuple, or dict of strings or 4-tuples
         The color of the nodes
-    node_ec : str, 4-tuple, or dict of strings or 4-tuples
+    node_edgecolor : str, 4-tuple, or dict of strings or 4-tuples
         The outline color of the nodes
-    node_lw : int, float, or dict of ints or floats
+    node_edgewidth : int, float, or dict of ints or floats
         The line weight of the outline of the nodes
     node_size : int, float, or dict of ints or floats
         The node radius
@@ -163,18 +185,25 @@ def draw_xgi_nodes(H, pos, ax, node_fc, node_ec, node_lw, node_size, zorder, set
         The layer on which to draw the nodes
     settings : dict
         Default parameters. Keys that may be useful to override default settings:
-        * node_fc_colormap
-        * node_lc_colormap
-        * min_node_lw
-        * max_node_lw
+        * node_facecolor_cmap
+        * node_lc_cmap
+        * min_node_edgewidth
+        * max_node_edgewidth
         * min_node_size
         * max_node_size
     """
     # Note Iterable covers lists, tuples, ranges, generators, np.ndarrays, etc
-    node_fc = _color_arg_to_dict(node_fc, H.nodes, settings["node_fc_colormap"])
-    node_ec = _color_arg_to_dict(node_ec, H.nodes, settings["node_lc_colormap"])
-    node_lw = _scalar_arg_to_dict(
-        node_lw, H.nodes, settings["min_node_lw"], settings["max_node_lw"]
+    node_facecolor = _color_arg_to_dict(
+        node_facecolor, H.nodes, settings["node_facecolor_cmap"]
+    )
+    node_edgecolor = _color_arg_to_dict(
+        node_edgecolor, H.nodes, settings["node_lc_cmap"]
+    )
+    node_edgewidth = _scalar_arg_to_dict(
+        node_edgewidth,
+        H.nodes,
+        settings["min_node_edgewidth"],
+        settings["max_node_edgewidth"],
     )
     node_size = _scalar_arg_to_dict(
         node_size, H.nodes, settings["min_node_size"], settings["max_node_size"]
@@ -186,14 +215,16 @@ def draw_xgi_nodes(H, pos, ax, node_fc, node_ec, node_lw, node_size, zorder, set
             x,
             y,
             s=node_size[i] ** 2,
-            c=node_fc[i],
-            edgecolors=node_ec[i],
-            linewidths=node_lw[i],
+            c=node_facecolor[i],
+            edgecolors=node_edgecolor[i],
+            linewidths=node_edgewidth[i],
             zorder=zorder,
         )
 
 
-def draw_xgi_hyperedges(H, pos, ax, edge_lc, edge_lw, edge_fc, d_max, settings):
+def draw_xgi_hyperedges(
+    H, pos, ax, link_color, link_width, edge_facecolor, d_max, settings
+):
     """Draw hyperedges.
 
     Parameters
@@ -204,30 +235,32 @@ def draw_xgi_hyperedges(H, pos, ax, edge_lc, edge_lw, edge_fc, d_max, settings):
         A hypergraph
     pos : dict of lists
         x,y position of every node
-    edge_lc : str, 4-tuple, or dict of 4-tuples or strings
+    link_color : str, 4-tuple, or dict of 4-tuples or strings
         The color of the pairwise edges
-    edge_lw : int, float, or dict
+    link_width : int, float, or dict
         Pairwise edge widths
-    edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
+    edge_facecolor : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
         Color of hyperedges
     settings : dict
         Default parameters. Keys that may be useful to override default settings:
-        * edge_lc_colormap
-        * min_edge_lw
-        * max_edge_lw
-        * edge_fc_colormap
+        * link_color_cmap
+        * min_link_width
+        * max_link_width
+        * edge_facecolor_cmap
 
     Raises
     ------
     XGIError
         If a SimplicialComplex is passed.
     """
-    edge_lc = _color_arg_to_dict(edge_lc, H.edges, settings["edge_lc_colormap"])
-    edge_lw = _scalar_arg_to_dict(
-        edge_lw, H.edges, settings["min_edge_lw"], settings["max_edge_lw"]
+    link_color = _color_arg_to_dict(link_color, H.edges, settings["link_color_cmap"])
+    link_width = _scalar_arg_to_dict(
+        link_width, H.edges, settings["min_link_width"], settings["max_link_width"]
     )
 
-    edge_fc = _color_arg_to_dict(edge_fc, H.edges, settings["edge_fc_colormap"])
+    edge_facecolor = _color_arg_to_dict(
+        edge_facecolor, H.edges, settings["edge_facecolor_cmap"]
+    )
     # Looping over the hyperedges of different order (reversed) -- nodes will be plotted separately
 
     for id, he in H.edges.members(dtype=dict).items():
@@ -238,7 +271,11 @@ def draw_xgi_hyperedges(H, pos, ax, edge_lc, edge_lw, edge_fc, d_max, settings):
             x_coords = [pos[he[0]][0], pos[he[1]][0]]
             y_coords = [pos[he[0]][1], pos[he[1]][1]]
             line = plt.Line2D(
-                x_coords, y_coords, color=edge_lc[id], lw=edge_lw[id], zorder=d_max - 1
+                x_coords,
+                y_coords,
+                color=link_color[id],
+                lw=link_width[id],
+                zorder=d_max - 1,
             )
             ax.add_line(line)
 
@@ -250,7 +287,7 @@ def draw_xgi_hyperedges(H, pos, ax, edge_lc, edge_lw, edge_fc, d_max, settings):
             sorted_coordinates = _CCW_sort(coordinates)
             obj = plt.Polygon(
                 sorted_coordinates,
-                facecolor=edge_fc[id],
+                facecolor=edge_facecolor[id],
                 alpha=0.4,
                 lw=0.5,
                 zorder=d_max - d,
@@ -258,7 +295,7 @@ def draw_xgi_hyperedges(H, pos, ax, edge_lc, edge_lw, edge_fc, d_max, settings):
             ax.add_patch(obj)
 
 
-def draw_xgi_simplices(SC, pos, ax, edge_lc, edge_lw, edge_fc, settings):
+def draw_xgi_simplices(SC, pos, ax, link_color, link_width, edge_facecolor, settings):
     """Draw maximal simplices and pairwise faces.
 
     Parameters
@@ -269,18 +306,18 @@ def draw_xgi_simplices(SC, pos, ax, edge_lc, edge_lw, edge_fc, settings):
         A simpicial complex
     pos : dict of lists
         x,y position of every node
-    edge_lc : str, 4-tuple, or dict of 4-tuples or strings
+    link_color : str, 4-tuple, or dict of 4-tuples or strings
         The color of the pairwise edges
-    edge_lw : int, float, or dict
+    link_width : int, float, or dict
         Pairwise edge widths
-    edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
+    edge_facecolor : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
         Color of simplices
     settings : dict
         Default parameters. Keys that may be useful to override default settings:
-        * edge_lc_colormap
-        * min_edge_lw
-        * max_edge_lw
-        * edge_fc_colormap
+        * link_color_cmap
+        * min_link_width
+        * max_link_width
+        * edge_facecolor_cmap
 
     Raises
     ------
@@ -290,15 +327,17 @@ def draw_xgi_simplices(SC, pos, ax, edge_lc, edge_lw, edge_fc, settings):
     # I will only plot the maximal simplices, so I convert the SC to H
     H_ = convert.from_simplicial_complex_to_hypergraph(SC)
 
-    edge_lc = _color_arg_to_dict(edge_lc, H_.edges, settings["edge_lc_colormap"])
-    edge_lw = _scalar_arg_to_dict(
-        edge_lw,
+    link_color = _color_arg_to_dict(link_color, H_.edges, settings["link_color_cmap"])
+    link_width = _scalar_arg_to_dict(
+        link_width,
         H_.edges,
-        settings["min_edge_lw"],
-        settings["max_edge_lw"],
+        settings["min_link_width"],
+        settings["max_link_width"],
     )
 
-    edge_fc = _color_arg_to_dict(edge_fc, H_.edges, settings["edge_fc_colormap"])
+    edge_facecolor = _color_arg_to_dict(
+        edge_facecolor, H_.edges, settings["edge_facecolor_cmap"]
+    )
     # Looping over the hyperedges of different order (reversed) -- nodes will be plotted separately
     for id, he in H_.edges.members(dtype=dict).items():
         d = len(he) - 1
@@ -308,7 +347,9 @@ def draw_xgi_simplices(SC, pos, ax, edge_lc, edge_lw, edge_fc, settings):
             x_coords = [pos[he[0]][0], pos[he[1]][0]]
             y_coords = [pos[he[0]][1], pos[he[1]][1]]
 
-            line = plt.Line2D(x_coords, y_coords, color=edge_lc[id], lw=edge_lw[id])
+            line = plt.Line2D(
+                x_coords, y_coords, color=link_color[id], lw=link_width[id]
+            )
             ax.add_line(line)
         else:
             # Hyperedges of order d (d=1: links, etc.)
@@ -318,7 +359,7 @@ def draw_xgi_simplices(SC, pos, ax, edge_lc, edge_lw, edge_fc, settings):
             sorted_coordinates = _CCW_sort(coordinates)
             obj = plt.Polygon(
                 sorted_coordinates,
-                facecolor=edge_fc[id],
+                facecolor=edge_facecolor[id],
                 alpha=0.4,
                 lw=0.5,
             )
@@ -327,7 +368,9 @@ def draw_xgi_simplices(SC, pos, ax, edge_lc, edge_lw, edge_fc, settings):
             for i, j in combinations(sorted_coordinates, 2):
                 x_coords = [i[0], j[0]]
                 y_coords = [i[1], j[1]]
-                line = plt.Line2D(x_coords, y_coords, color=edge_lc[id], lw=edge_lw[id])
+                line = plt.Line2D(
+                    x_coords, y_coords, color=link_color[id], lw=link_width[id]
+                )
                 ax.add_line(line)
 
 

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -64,6 +64,9 @@ def draw(
     edge_lw :  float (default=1.5)
     Line width of edges of order 1 (dyadic links).
 
+    edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
+    Color of hyperedges
+
     node_fc : color (str, dict, or iterable, default='white')
     Color of the nodes.  If str, use the same color for all nodes.  If a dict, must
     contain (node_id: color_str) pairs.  If other iterable, assume the colors are
@@ -135,17 +138,17 @@ def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_lw, node_size, zorder, set
     H : Hypergraph or SimplicialComplex
         Higher-order network to plot
     pos : dict of lists
-        the x, y position of every node
+        The x, y position of every node
     node_fc : str, 4-tuple, or dict of strings or 4-tuples
-        the color of the nodes
+        The color of the nodes
     node_ec : str, 4-tuple, or dict of strings or 4-tuples
-        the outline color of the nodes
+        The outline color of the nodes
     node_lw : int, float, or dict of ints or floats
-        the line weight of the outline of the nodes
+        The line weight of the outline of the nodes
     node_size : int, float, or dict of ints or floats
-        the node radius
+        The node radius
     zorder : int
-        the layer on which to draw the nodes
+        The layer on which to draw the nodes
     """
     # Note Iterable covers lists, tuples, ranges, generators, np.ndarrays, etc
     node_fc = _color_arg_to_dict(node_fc, H.nodes, settings["node_colormap"])
@@ -172,17 +175,17 @@ def draw_xgi_hyperedges(ax, H, pos, edge_lc, edge_lw, edge_fc, d_max, settings):
     Parameters
     ----------
     ax : axis handle
-        figure axes to plot onto
+        Figure axes to plot onto
     H : Hypergraph
         A hypergraph
     pos : dict of lists
         x,y position of every node
     edge_lc : str, 4-tuple, or dict of 4-tuples or strings
-        the color of the pairwise edges
+        The color of the pairwise edges
     edge_lw : int, float, or dict
-        pairwise edge widths
+        Pairwise edge widths
     edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
-        color of hyperedges
+        Color of hyperedges
     """
     edge_lc = _color_arg_to_dict(edge_lc, H.edges, settings["edge_outline_colormap"])
     edge_lw = _scalar_arg_to_dict(edge_lw, H.edges, settings["min_edge_linewidth"], settings["max_edge_linewidth"])
@@ -225,17 +228,17 @@ def draw_xgi_complexes(ax, SC, pos, edge_lc, edge_lw, edge_fc, settings):
     Parameters
     ----------
     ax : axis handle
-        figure axes to plot onto
+        Figure axes to plot onto
     SC : SimplicialComplex
-        A simpicial comples
+        A simpicial complex
     pos : dict of lists
         x,y position of every node
     edge_lc : str, 4-tuple, or dict of 4-tuples or strings
-        the color of the pairwise edges
+        The color of the pairwise edges
     edge_lw : int, float, or dict
-        pairwise edge widths
+        Pairwise edge widths
     edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
-        color of simplices
+        Color of simplices
     """
     # I will only plot the maximal simplices, so I convert the SC to H
     H_ = convert.from_simplicial_complex_to_hypergraph(SC)
@@ -277,24 +280,24 @@ def draw_xgi_complexes(ax, SC, pos, edge_lc, edge_lw, edge_fc, settings):
 
 
 def _scalar_arg_to_dict(arg, ids, min_val, max_val):
-    """Map different types of arguments for drawing style to a dict.
+    """Map different types of arguments for drawing style to a dict with scalar values.
 
     Parameters
     ----------
     arg : str, dict, or iterable
-        attributes for drawing parameter
+        Attributes for drawing parameter
     ids : NodeView or EdgeView
         This is the node or edge IDs that attributes get mapped to.
 
     Returns
     -------
     dict
-        an ID: attribute dictionary
+        An ID: attribute dictionary
 
     Raises
     ------
     TypeError
-        if a string, list, or dict is not passed
+        If a string, list, or dict is not passed
     """
     if isinstance(arg, dict):
         return {id: arg[id] for id in arg if id in ids}
@@ -313,7 +316,25 @@ def _scalar_arg_to_dict(arg, ids, min_val, max_val):
 
 
 def _color_arg_to_dict(arg, ids, cmap):
-    print(type(arg))
+    """Map different types of arguments for drawing style to a dict with color values.
+
+    Parameters
+    ----------
+    arg : str, dict, or iterable
+        Attributes for drawing parameter
+    ids : NodeView or EdgeView
+        This is the node or edge IDs that attributes get mapped to.
+
+    Returns
+    -------
+    dict
+        An ID: attribute dictionary
+
+    Raises
+    ------
+    TypeError
+        If a string, list, or dict is not passed
+    """
     if isinstance(arg, dict):
         return {id: arg[id] for id in arg if id in ids}
     if type(arg) in [tuple, str]:

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -92,9 +92,9 @@ def draw(
 
     """
     settings = {
-        "min_node_size": 5,
-        "max_node_size": 10,
-        "min_edge_linewidth": 1,
+        "min_node_size": 10,
+        "max_node_size": 30,
+        "min_edge_linewidth": 2,
         "max_edge_linewidth": 10,
         "min_node_linewidth": 1,
         "max_node_linewidth": 5,
@@ -103,6 +103,11 @@ def draw(
         "edge_face_colormap": cm.Blues,
         "edge_outline_colormap": cm.Greys,
     }
+
+    settings.update(kwargs)
+
+    if edge_fc is None:
+        edge_fc = H.edges.size
 
     if pos is None:
         pos = barycenter_spring_layout(H)
@@ -153,8 +158,8 @@ def draw_xgi_nodes(ax, H, pos, node_fc, node_ec, node_lw, node_size, zorder, set
     # Note Iterable covers lists, tuples, ranges, generators, np.ndarrays, etc
     node_fc = _color_arg_to_dict(node_fc, H.nodes, settings["node_colormap"])
     node_ec = _color_arg_to_dict(node_ec, H.nodes, settings["node_outline_colormap"])
-    node_lw = _scalar_arg_to_dict(node_lw, H.nodes, settings["min_node_linewidth"], settings["min_node_linewidth"])
-    node_size = _scalar_arg_to_dict(node_size, H.nodes, settings["min_node_size"], settings["min_node_size"])
+    node_lw = _scalar_arg_to_dict(node_lw, H.nodes, settings["min_node_linewidth"], settings["max_node_linewidth"])
+    node_size = _scalar_arg_to_dict(node_size, H.nodes, settings["min_node_size"], settings["max_node_size"])
 
     for i in H.nodes:
         (x, y) = pos[i]
@@ -301,7 +306,7 @@ def _scalar_arg_to_dict(arg, ids, min_val, max_val):
     """
     if isinstance(arg, dict):
         return {id: arg[id] for id in arg if id in ids}
-    if type(arg) in [int, float]:
+    elif type(arg) in [int, float]:
         return {id: arg for id in ids}
     elif isinstance(arg, NodeStat) or isinstance(arg, EdgeStat):
         f = lambda val: np.interp(val, [arg.min(), arg.max()], [min_val, max_val])
@@ -337,17 +342,16 @@ def _color_arg_to_dict(arg, ids, cmap):
     """
     if isinstance(arg, dict):
         return {id: arg[id] for id in arg if id in ids}
-    if type(arg) in [tuple, str]:
+    elif type(arg) in [tuple, str]:
         return {id: arg for id in ids}
     elif isinstance(arg, NodeStat) or isinstance(arg, EdgeStat):
         if isinstance(cmap, ListedColormap):
             f = lambda val: np.interp(val, [arg.min(), arg.max()], [0, cmap.N])
         elif isinstance(cmap, LinearSegmentedColormap):
-            f = lambda val: np.interp(val, [arg.min(), arg.max()], [0, 1])
+            f = lambda val: np.interp(val, [arg.min(), arg.max()], [0.1, 0.9])
         else:
             raise XGIError("Invalid colormap!")
         s = arg.asdict()
-        print({id: cmap(f(s[id])) for id in ids})
         return {id: cmap(f(s[id])) for id in ids}
     elif isinstance(arg, Iterable):
         return {id: arg[idx] for idx, id in enumerate(ids)}

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -29,12 +29,12 @@ def draw(
     H,
     pos=None,
     ax=None,
-    link_color="black",
-    link_width=1.5,
-    edge_facecolor=None,
-    node_facecolor="white",
-    node_edgecolor="black",
-    node_edgewidth=1,
+    dyad_color="black",
+    dyad_lw=1.5,
+    edge_fc=None,
+    node_fc="white",
+    node_ec="black",
+    node_lw=1,
     node_size=10,
     **kwargs,
 ):
@@ -50,29 +50,29 @@ def draw(
 
     ax : matplotlib.pyplot.axes (default=None)
 
-    link_color : color (str, dict, or iterable, default='black')
+    dyad_color : color (str, dict, or iterable, default='black')
         Color of the dyadic links.  If str, use the
         same color for all edges.  If a dict, must contain (edge_id: color_str) pairs.  If
         iterable, assume the colors are specified in the same order as the edges are found
         in H.edges.
 
-    link_width :  float (default=1.5)
+    dyad_lw :  float (default=1.5)
         Line width of edges of order 1 (dyadic links).
 
-    edge_facecolor : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
+    edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
         Color of hyperedges
 
-    node_facecolor : color (str, dict, or iterable, default='white')
+    node_fc : color (str, dict, or iterable, default='white')
         Color of the nodes.  If str, use the same color for all nodes.  If a dict, must
         contain (node_id: color_str) pairs.  If other iterable, assume the colors are
         specified in the same order as the nodes are found in H.nodes.
 
-    node_edgecolor : color (dict or str, default='black')
+    node_ec : color (dict or str, default='black')
         Color of node borders.  If str, use the same color for all nodes.  If a dict, must
         contain (node_id: color_str) pairs.  If other iterable, assume the colors are
         specified in the same order as the nodes are found in H.nodes.
 
-    node_edgewidth : float (default=1.0)
+    node_lw : float (default=1.0)
         Line width of the node borders in pixels.
 
     node_size : float (default=0.03)
@@ -82,14 +82,14 @@ def draw(
         alternate default values. Values that can be overwritten are the following:
         * min_node_size
         * max_node_size
-        * min_link_width
-        * max_link_width
-        * min_node_edgewidth
-        * max_node_edgewidth
-        * node_facecolor_cmap
+        * min_dyad_lw
+        * max_dyad_lw
+        * min_node_lw
+        * max_node_lw
+        * node_fc_cmap
         * node_lc_cmap
-        * edge_facecolor_cmap
-        * link_color_cmap
+        * edge_fc_cmap
+        * dyad_color_cmap
 
     Examples
     --------
@@ -102,20 +102,20 @@ def draw(
     settings = {
         "min_node_size": 10,
         "max_node_size": 30,
-        "min_link_width": 2,
-        "max_link_width": 10,
-        "min_node_edgewidth": 1,
-        "max_node_edgewidth": 5,
-        "node_facecolor_cmap": cm.Reds,
+        "min_dyad_lw": 2,
+        "max_dyad_lw": 10,
+        "min_node_lw": 1,
+        "max_node_lw": 5,
+        "node_fc_cmap": cm.Reds,
         "node_lc_cmap": cm.Greys,
-        "edge_facecolor_cmap": cm.Blues,
-        "link_color_cmap": cm.Greys,
+        "edge_fc_cmap": cm.Blues,
+        "dyad_color_cmap": cm.Greys,
     }
 
     settings.update(kwargs)
 
-    if edge_facecolor is None:
-        edge_facecolor = H.edges.size
+    if edge_fc is None:
+        edge_fc = H.edges.size
 
     if pos is None:
         pos = barycenter_spring_layout(H)
@@ -131,10 +131,10 @@ def draw(
     d_max = max_edge_order(H)
 
     if isinstance(H, SimplicialComplex):
-        draw_xgi_simplices(H, pos, ax, link_color, link_width, edge_facecolor, settings)
+        draw_xgi_simplices(H, pos, ax, dyad_color, dyad_lw, edge_fc, settings)
     elif isinstance(H, Hypergraph):
         draw_xgi_hyperedges(
-            H, pos, ax, link_color, link_width, edge_facecolor, d_max, settings
+            H, pos, ax, dyad_color, dyad_lw, edge_fc, d_max, settings
         )
     else:
         raise XGIError("The input must be a SimplicialComplex or Hypergraph")
@@ -143,9 +143,9 @@ def draw(
         H,
         pos,
         ax,
-        node_facecolor,
-        node_edgecolor,
-        node_edgewidth,
+        node_fc,
+        node_ec,
+        node_lw,
         node_size,
         d_max,
         settings,
@@ -156,9 +156,9 @@ def draw_xgi_nodes(
     H,
     pos,
     ax,
-    node_facecolor,
-    node_edgecolor,
-    node_edgewidth,
+    node_fc,
+    node_ec,
+    node_lw,
     node_size,
     zorder,
     settings,
@@ -173,11 +173,11 @@ def draw_xgi_nodes(
         Higher-order network to plot
     pos : dict of lists
         The x, y position of every node
-    node_facecolor : str, 4-tuple, or dict of strings or 4-tuples
-        The color of the nodes
-    node_edgecolor : str, 4-tuple, or dict of strings or 4-tuples
+    node_fc : str, 4-tuple, or dict of strings or 4-tuples
+        The face color of the nodes
+    node_ec : str, 4-tuple, or dict of strings or 4-tuples
         The outline color of the nodes
-    node_edgewidth : int, float, or dict of ints or floats
+    node_lw : int, float, or dict of ints or floats
         The line weight of the outline of the nodes
     node_size : int, float, or dict of ints or floats
         The node radius
@@ -185,25 +185,25 @@ def draw_xgi_nodes(
         The layer on which to draw the nodes
     settings : dict
         Default parameters. Keys that may be useful to override default settings:
-        * node_facecolor_cmap
+        * node_fc_cmap
         * node_lc_cmap
-        * min_node_edgewidth
-        * max_node_edgewidth
+        * min_node_lw
+        * max_node_lw
         * min_node_size
         * max_node_size
     """
     # Note Iterable covers lists, tuples, ranges, generators, np.ndarrays, etc
-    node_facecolor = _color_arg_to_dict(
-        node_facecolor, H.nodes, settings["node_facecolor_cmap"]
+    node_fc = _color_arg_to_dict(
+        node_fc, H.nodes, settings["node_fc_cmap"]
     )
-    node_edgecolor = _color_arg_to_dict(
-        node_edgecolor, H.nodes, settings["node_lc_cmap"]
+    node_ec = _color_arg_to_dict(
+        node_ec, H.nodes, settings["node_lc_cmap"]
     )
-    node_edgewidth = _scalar_arg_to_dict(
-        node_edgewidth,
+    node_lw = _scalar_arg_to_dict(
+        node_lw,
         H.nodes,
-        settings["min_node_edgewidth"],
-        settings["max_node_edgewidth"],
+        settings["min_node_lw"],
+        settings["max_node_lw"],
     )
     node_size = _scalar_arg_to_dict(
         node_size, H.nodes, settings["min_node_size"], settings["max_node_size"]
@@ -215,15 +215,15 @@ def draw_xgi_nodes(
             x,
             y,
             s=node_size[i] ** 2,
-            c=node_facecolor[i],
-            edgecolors=node_edgecolor[i],
-            linewidths=node_edgewidth[i],
+            c=node_fc[i],
+            edgecolors=node_ec[i],
+            linewidths=node_lw[i],
             zorder=zorder,
         )
 
 
 def draw_xgi_hyperedges(
-    H, pos, ax, link_color, link_width, edge_facecolor, d_max, settings
+    H, pos, ax, dyad_color, dyad_lw, edge_fc, d_max, settings
 ):
     """Draw hyperedges.
 
@@ -235,31 +235,31 @@ def draw_xgi_hyperedges(
         A hypergraph
     pos : dict of lists
         x,y position of every node
-    link_color : str, 4-tuple, or dict of 4-tuples or strings
+    dyad_color : str, 4-tuple, or dict of 4-tuples or strings
         The color of the pairwise edges
-    link_width : int, float, or dict
+    dyad_lw : int, float, or dict
         Pairwise edge widths
-    edge_facecolor : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
+    edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
         Color of hyperedges
     settings : dict
         Default parameters. Keys that may be useful to override default settings:
-        * link_color_cmap
-        * min_link_width
-        * max_link_width
-        * edge_facecolor_cmap
+        * dyad_color_cmap
+        * min_dyad_lw
+        * max_dyad_lw
+        * edge_fc_cmap
 
     Raises
     ------
     XGIError
         If a SimplicialComplex is passed.
     """
-    link_color = _color_arg_to_dict(link_color, H.edges, settings["link_color_cmap"])
-    link_width = _scalar_arg_to_dict(
-        link_width, H.edges, settings["min_link_width"], settings["max_link_width"]
+    dyad_color = _color_arg_to_dict(dyad_color, H.edges, settings["dyad_color_cmap"])
+    dyad_lw = _scalar_arg_to_dict(
+        dyad_lw, H.edges, settings["min_dyad_lw"], settings["max_dyad_lw"]
     )
 
-    edge_facecolor = _color_arg_to_dict(
-        edge_facecolor, H.edges, settings["edge_facecolor_cmap"]
+    edge_fc = _color_arg_to_dict(
+        edge_fc, H.edges, settings["edge_fc_cmap"]
     )
     # Looping over the hyperedges of different order (reversed) -- nodes will be plotted separately
 
@@ -273,8 +273,8 @@ def draw_xgi_hyperedges(
             line = plt.Line2D(
                 x_coords,
                 y_coords,
-                color=link_color[id],
-                lw=link_width[id],
+                color=dyad_color[id],
+                lw=dyad_lw[id],
                 zorder=d_max - 1,
             )
             ax.add_line(line)
@@ -287,15 +287,14 @@ def draw_xgi_hyperedges(
             sorted_coordinates = _CCW_sort(coordinates)
             obj = plt.Polygon(
                 sorted_coordinates,
-                facecolor=edge_facecolor[id],
+                facecolor=edge_fc[id],
                 alpha=0.4,
-                lw=0.5,
                 zorder=d_max - d,
             )
             ax.add_patch(obj)
 
 
-def draw_xgi_simplices(SC, pos, ax, link_color, link_width, edge_facecolor, settings):
+def draw_xgi_simplices(SC, pos, ax, dyad_color, dyad_lw, edge_fc, settings):
     """Draw maximal simplices and pairwise faces.
 
     Parameters
@@ -306,18 +305,18 @@ def draw_xgi_simplices(SC, pos, ax, link_color, link_width, edge_facecolor, sett
         A simpicial complex
     pos : dict of lists
         x,y position of every node
-    link_color : str, 4-tuple, or dict of 4-tuples or strings
+    dyad_color : str, 4-tuple, or dict of 4-tuples or strings
         The color of the pairwise edges
-    link_width : int, float, or dict
+    dyad_lw : int, float, or dict
         Pairwise edge widths
-    edge_facecolor : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
+    edge_fc : str, 4-tuple, ListedColormap, LinearSegmentedColormap, or dict of 4-tuples or strings
         Color of simplices
     settings : dict
         Default parameters. Keys that may be useful to override default settings:
-        * link_color_cmap
-        * min_link_width
-        * max_link_width
-        * edge_facecolor_cmap
+        * dyad_color_cmap
+        * min_dyad_lw
+        * max_dyad_lw
+        * edge_fc_cmap
 
     Raises
     ------
@@ -327,16 +326,16 @@ def draw_xgi_simplices(SC, pos, ax, link_color, link_width, edge_facecolor, sett
     # I will only plot the maximal simplices, so I convert the SC to H
     H_ = convert.from_simplicial_complex_to_hypergraph(SC)
 
-    link_color = _color_arg_to_dict(link_color, H_.edges, settings["link_color_cmap"])
-    link_width = _scalar_arg_to_dict(
-        link_width,
+    dyad_color = _color_arg_to_dict(dyad_color, H_.edges, settings["dyad_color_cmap"])
+    dyad_lw = _scalar_arg_to_dict(
+        dyad_lw,
         H_.edges,
-        settings["min_link_width"],
-        settings["max_link_width"],
+        settings["min_dyad_lw"],
+        settings["max_dyad_lw"],
     )
 
-    edge_facecolor = _color_arg_to_dict(
-        edge_facecolor, H_.edges, settings["edge_facecolor_cmap"]
+    edge_fc = _color_arg_to_dict(
+        edge_fc, H_.edges, settings["edge_fc_cmap"]
     )
     # Looping over the hyperedges of different order (reversed) -- nodes will be plotted separately
     for id, he in H_.edges.members(dtype=dict).items():
@@ -348,7 +347,7 @@ def draw_xgi_simplices(SC, pos, ax, link_color, link_width, edge_facecolor, sett
             y_coords = [pos[he[0]][1], pos[he[1]][1]]
 
             line = plt.Line2D(
-                x_coords, y_coords, color=link_color[id], lw=link_width[id]
+                x_coords, y_coords, color=dyad_color[id], lw=dyad_lw[id]
             )
             ax.add_line(line)
         else:
@@ -359,9 +358,8 @@ def draw_xgi_simplices(SC, pos, ax, link_color, link_width, edge_facecolor, sett
             sorted_coordinates = _CCW_sort(coordinates)
             obj = plt.Polygon(
                 sorted_coordinates,
-                facecolor=edge_facecolor[id],
+                facecolor=edge_fc[id],
                 alpha=0.4,
-                lw=0.5,
             )
             ax.add_patch(obj)
             # Drawing the all the edges within
@@ -369,7 +367,7 @@ def draw_xgi_simplices(SC, pos, ax, link_color, link_width, edge_facecolor, sett
                 x_coords = [i[0], j[0]]
                 y_coords = [i[1], j[1]]
                 line = plt.Line2D(
-                    x_coords, y_coords, color=link_color[id], lw=link_width[id]
+                    x_coords, y_coords, color=dyad_color[id], lw=dyad_lw[id]
                 )
                 ax.add_line(line)
 

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -300,12 +300,12 @@ def _scalar_arg_to_dict(arg, ids, min_val, max_val):
         return {id: arg[id] for id in arg if id in ids}
     if type(arg) in [int, float]:
         return {id: arg for id in ids}
-    elif isinstance(arg, Iterable):
-        return {id: arg[idx] for idx, id in enumerate(ids)}
     elif isinstance(arg, NodeStat) or isinstance(arg, EdgeStat):
         f = lambda val: np.interp(val, [arg.min(), arg.max()], [min_val, max_val])
         s = arg.asdict()
         return {id: f(s[id]) for id in ids}
+    elif isinstance(arg, Iterable):
+        return {id: arg[idx] for idx, id in enumerate(ids)}
     else:
         raise TypeError(
             f"argument must be dict, str, or iterable, received {type(arg)}"
@@ -318,8 +318,6 @@ def _color_arg_to_dict(arg, ids, cmap):
         return {id: arg[id] for id in arg if id in ids}
     if type(arg) in [tuple, str]:
         return {id: arg for id in ids}
-    elif isinstance(arg, Iterable):
-        return {id: arg[idx] for idx, id in enumerate(ids)}
     elif isinstance(arg, NodeStat) or isinstance(arg, EdgeStat):
         if isinstance(cmap, ListedColormap):
             f = lambda val: np.interp(val, [arg.min(), arg.max()], [0, cmap.N])
@@ -330,6 +328,8 @@ def _color_arg_to_dict(arg, ids, cmap):
         s = arg.asdict()
         print({id: cmap(f(s[id])) for id in ids})
         return {id: cmap(f(s[id])) for id in ids}
+    elif isinstance(arg, Iterable):
+        return {id: arg[idx] for idx, id in enumerate(ids)}
     else:
         raise TypeError(
             f"argument must be dict, str, or iterable, received {type(arg)}"

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -14,11 +14,10 @@ import numpy as np
 from matplotlib import cm
 from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 
-from ..stats import EdgeStat, NodeStat
-
 from .. import convert
 from ..classes import Hypergraph, SimplicialComplex, max_edge_order
 from ..exception import XGIError
+from ..stats import EdgeStat, NodeStat
 from .layout import barycenter_spring_layout
 
 __all__ = [
@@ -131,11 +130,10 @@ def draw(
 
     d_max = max_edge_order(H)
 
-    if isinstance(H, Hypergraph):
+    if isinstance(H, SimplicialComplex):
+        draw_xgi_simplices(H, pos, ax, edge_lc, edge_lw, edge_fc, settings)
+    elif isinstance(H, Hypergraph):
         draw_xgi_hyperedges(H, pos, ax, edge_lc, edge_lw, edge_fc, d_max, settings)
-
-    elif isinstance(H, SimplicialComplex):
-        draw_xgi_simplices(H, pos, ax, edge_lc, edge_lw, edge_fc, d_max, settings)
     else:
         raise XGIError("The input must be a SimplicialComplex or Hypergraph")
 
@@ -224,8 +222,6 @@ def draw_xgi_hyperedges(H, pos, ax, edge_lc, edge_lw, edge_fc, d_max, settings):
     XGIError
         If a SimplicialComplex is passed.
     """
-    if isinstance(H, SimplicialComplex):
-        raise XGIError("Use draw_xgi_simplices instead.")
     edge_lc = _color_arg_to_dict(edge_lc, H.edges, settings["edge_lc_colormap"])
     edge_lw = _scalar_arg_to_dict(
         edge_lw, H.edges, settings["min_edge_lw"], settings["max_edge_lw"]
@@ -285,14 +281,12 @@ def draw_xgi_simplices(SC, pos, ax, edge_lc, edge_lw, edge_fc, settings):
         * min_edge_lw
         * max_edge_lw
         * edge_fc_colormap
-    
+
     Raises
     ------
     XGIError
         If a SimplicialComplex is passed.
     """
-    if isinstance(SC, Hypergraph):
-        raise XGIError("Use draw_xgi_hyperedges instead.")
     # I will only plot the maximal simplices, so I convert the SC to H
     H_ = convert.from_simplicial_complex_to_hypergraph(SC)
 
@@ -313,7 +307,8 @@ def draw_xgi_simplices(SC, pos, ax, edge_lc, edge_lw, edge_fc, settings):
             he = list(he)
             x_coords = [pos[he[0]][0], pos[he[1]][0]]
             y_coords = [pos[he[0]][1], pos[he[1]][1]]
-            line = plt.Line2D(x_coords, y_coords, color=edge_lc[id], lw=edge_lw[i])
+
+            line = plt.Line2D(x_coords, y_coords, color=edge_lc[id], lw=edge_lw[id])
             ax.add_line(line)
         else:
             # Hyperedges of order d (d=1: links, etc.)


### PR DESCRIPTION
Users can now specify NodeStats or EdgeStats as drawing parameters in addition to specifying them directly with a single value, an iterable or a dictionary. Also fixed `CEC_centrality` so that it outputs a dict of floats, not a dict of 1D numpy arrays.