### PR TITLE
Make filterby() accept NodeStat and EdgeStat objects 

### DIFF
--- a/tests/stats/test_edgestats.py
+++ b/tests/stats/test_edgestats.py
@@ -29,6 +29,14 @@ def test_call_filterby(edgelist1, edgelist8):
     assert H.edges([5, 6]).filterby("order", 2).size.asdict() == {5: 3, 6: 3}
 
 
+def test_filterby_with_nodestat(edgelist4, edgelist8):
+    H = xgi.Hypergraph(edgelist4)
+    assert list(H.edges.filterby(H.edges.order(degree=2), 2)) == [1]
+
+    H = xgi.Hypergraph(edgelist8)
+    assert list(H.edges.filterby(H.edges.order(degree=4), 1)) == [2, 3]
+
+
 def test_single_node(edgelist1):
     H = xgi.Hypergraph(edgelist1)
     assert H.order()[1] == 0

--- a/tests/stats/test_nodestats.py
+++ b/tests/stats/test_nodestats.py
@@ -27,6 +27,14 @@ def test_filterby(edgelist1, edgelist8):
     assert H.nodes.filterby("average_neighbor_degree", 4.2).degree.asdict() == {4: 3}
 
 
+def test_filterby_with_nodestat(edgelist4, edgelist8):
+    H = xgi.Hypergraph(edgelist4)
+    assert list(H.nodes.filterby(H.nodes.degree(order=2), 2)) == [3]
+
+    H = xgi.Hypergraph(edgelist8)
+    assert list(H.nodes.filterby(H.nodes.degree(order=2), 2)) == [1, 4, 5]
+
+
 def test_filterby_modes(edgelist1, edgelist8):
     H = xgi.Hypergraph(edgelist1)
     assert list(H.nodes.filterby("degree", 2)) == [6]

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -176,8 +176,8 @@ class IDView(Mapping, Set):
 
         Parameters
         ----------
-        stat : str
-            Name of a `NodeStat`.
+        stat : str or :class:`xgi.stats.NodeStat`
+            `NodeStat` object, or name of a `NodeStat`.
         val : Any
             Value of the statistic.  Usually a single numeric value.  When mode is
             'between', must be a tuple of exactly two values.
@@ -200,28 +200,44 @@ class IDView(Mapping, Set):
 
         Examples
         --------
+        By default, return the IDs whose value of the statistic is exactly equal to
+        `val`.
+
         >>> import xgi
         >>> H = xgi.Hypergraph([[1, 2, 3], [2, 3, 4, 5], [3, 4, 5]])
-        >>> H.nodes.filterby('degree', 2, 'eq')
+        >>> n = H.nodes
+        >>> n.filterby('degree', 2)
         NodeView((2, 4, 5))
-        >>> H.nodes.filterby('degree', 2, 'neq')
+
+        Can choose other comparison methods via `mode`.
+
+        >>> n.filterby('degree', 2, 'eq')
+        NodeView((2, 4, 5))
+        >>> n.filterby('degree', 2, 'neq')
         NodeView((1, 3))
-        >>> H.nodes.filterby('degree', 2, 'lt')
+        >>> n.filterby('degree', 2, 'lt')
         NodeView((1,))
-        >>> H.nodes.filterby('degree', 2, 'gt')
+        >>> n.filterby('degree', 2, 'gt')
         NodeView((3,))
-        >>> H.nodes.filterby('degree', 2, 'leq')
+        >>> n.filterby('degree', 2, 'leq')
         NodeView((1, 2, 4, 5))
-        >>> H.nodes.filterby('degree', 2, 'geq')
+        >>> n.filterby('degree', 2, 'geq')
         NodeView((2, 3, 4, 5))
-        >>> H.nodes.filterby('degree', (2, 3), 'between')
+        >>> n.filterby('degree', (2, 3), 'between')
         NodeView((2, 3, 4, 5))
 
+        Can also pass a :class:`NodeStat` object.
+
+        >>> n.filterby(n.degree(order=2), 2)
+        NodeView((3,))
+
         """
-        try:
-            stat = getattr(self._dispatcher, stat)
-        except AttributeError as e:
-            raise AttributeError(f'Statistic with name "{stat}" not found') from e
+        if not isinstance(stat, self._dispatcher.statsclass):
+            try:
+                stat = getattr(self._dispatcher, stat)
+            except AttributeError as e:
+                raise AttributeError(f'Statistic with name "{stat}" not found') from e
+
         values = stat.asdict()
         if mode == "eq":
             bunch = [idx for idx in self if values[idx] == val]

--- a/xgi/stats/edgestats.py
+++ b/xgi/stats/edgestats.py
@@ -114,6 +114,8 @@ def order(net, bunch, degree=None):
         The network.
     bunch : Iterable
         Edges in `net`.
+    degree : int | None
+        If not None (default), count only those member nodes with the specified degree.
 
     Returns
     -------
@@ -129,14 +131,15 @@ def order(net, bunch, degree=None):
     >>> H = xgi.Hypergraph([[1, 2, 3], [2, 3, 4, 5], [3, 4, 5]])
     >>> H.edges.order.asdict()
     {0: 2, 1: 3, 2: 2}
+    >>> H.edges.order(degree=2).asdict()
+    {0: 0, 1: 2, 2: 1}
 
     """
     if degree is None:
         return {e: len(net._edge[e]) - 1 for e in bunch}
     else:
         return {
-            e: len(n for n in net._edge[e] if len(net._node[n]) == degree) - 1
-            for e in bunch
+            e: sum(len(net._node[n]) == degree for n in net._edge[e]) - 1 for e in bunch
         }
 
 


### PR DESCRIPTION
Previously, it only accepted strings that were the name of valid NodeStat or EdgeStat, so this is a minor change.

Also fixed a bug in how the order of an edge was being computed.

Also added docs.

Fixes #135 