### PR TITLE
Refactor Hypergraph.copy()

### DIFF
--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -355,10 +355,12 @@ def test_add_edges_from_wrong_format():
 
 def test_copy(edgelist1):
     H = xgi.Hypergraph(edgelist1)
+    H["key"] = "value"
     copy = H.copy()
     assert list(copy.nodes) == list(H.nodes)
     assert list(copy.edges) == list(H.edges)
     assert list(copy.edges.members()) == list(H.edges.members())
+    assert H._hypergraph == copy._hypergraph
 
     H.add_node(10)
     assert list(copy.nodes) != list(H.nodes)
@@ -366,6 +368,17 @@ def test_copy(edgelist1):
 
     H.add_edge([1, 3, 5])
     assert list(copy.edges) != list(H.edges)
+
+    H["key2"] = "value2"
+    assert H._hypergraph != copy._hypergraph
+
+    copy.add_node(10)
+    copy.add_edge([1, 3, 5])
+    copy["key2"] = "value2"
+    assert list(copy.nodes) == list(H.nodes)
+    assert list(copy.edges) == list(H.edges)
+    assert list(copy.edges.members()) == list(H.edges.members())
+    assert H._hypergraph == copy._hypergraph
 
 
 def test_double_edge_swap(edgelist1):

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -381,6 +381,15 @@ def test_copy(edgelist1):
     assert H._hypergraph == copy._hypergraph
 
 
+def test_copy_issue128():
+    # see https://github.com/ComplexGroupInteractions/xgi/issues/128
+    H = xgi.Hypergraph()
+    H["key"] = "value"
+    K = H.copy()
+    K["key"] = "some_other_value"
+    assert H["key"] == "value"
+
+
 def test_double_edge_swap(edgelist1):
     H = xgi.Hypergraph(edgelist1)
 

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -950,7 +950,8 @@ class Hypergraph:
 
         # Then, we set the start at one plus the maximum edge ID that is an integer,
         # because count() only yields integer IDs.
-        copy._edge_uid = count(start=max(edges_with_int_id) + 1)
+        start = max(edges_with_int_id) + 1 if edges_with_int_id else 0
+        copy._edge_uid = count(start=start)
 
         return copy
 

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -937,7 +937,8 @@ class Hypergraph:
         copy.add_nodes_from((n, deepcopy(attr)) for n, attr in nn.items())
         ee = self.edges
         copy.add_edges_from(
-            (ee.members(e), e, deepcopy(attr)) for e, attr in ee.items()
+            (e, id, deepcopy(self.edges[id]))
+            for id, e in ee.members(dtype=dict).items()
         )
         copy._hypergraph = deepcopy(self._hypergraph)
 


### PR DESCRIPTION
Multiple things were Wrong with `copy()`:

1. It was using `subhypergraph()` which returns a frozen hypergraph (yikes!). I'm guilty of this one.
2. See #128 
3. A naive implementation of `copy()` would have had a bug when using `add_edge`. I fixed it in the current PR. See comment starting on line 944 in `hypergraph.py`.

Fixes #128.