### PR TITLE
Cleanup hypergraph methods

### DIFF
--- a/docs/source/api/classes/xgi.classes.hypergraph.Hypergraph.rst
+++ b/docs/source/api/classes/xgi.classes.hypergraph.Hypergraph.rst
@@ -46,11 +46,3 @@
 
       ~Hypergraph.copy
       ~Hypergraph.dual
-
-
-   .. rubric:: Methods that query nodes and edges
-
-   .. autosummary::
-      :nosignatures:
-
-      ~Hypergraph.has_edge

--- a/docs/source/api/classes/xgi.classes.hypergraph.Hypergraph.rst
+++ b/docs/source/api/classes/xgi.classes.hypergraph.Hypergraph.rst
@@ -33,7 +33,6 @@
       ~Hypergraph.remove_node
       ~Hypergraph.remove_edge
       ~Hypergraph.remove_nodes_from
-      ~Hypergraph.remove_nodes_from
       ~Hypergraph.remove_edges_from
       ~Hypergraph.remove_node_from_edge
       ~Hypergraph.clear

--- a/docs/source/api/classes/xgi.classes.hypergraph.Hypergraph.rst
+++ b/docs/source/api/classes/xgi.classes.hypergraph.Hypergraph.rst
@@ -53,5 +53,4 @@
    .. autosummary::
       :nosignatures:
 
-      ~Hypergraph.duplicate_edges
       ~Hypergraph.has_edge

--- a/docs/source/api/classes/xgi.classes.reportviews.EdgeView.rst
+++ b/docs/source/api/classes/xgi.classes.reportviews.EdgeView.rst
@@ -24,5 +24,6 @@ xgi.classes.reportviews.EdgeView
       ~EdgeView.singletons
       ~IDView.neighbors
       ~IDView.duplicates
+      ~IDView.lookup
       ~IDView.filterby
       ~IDView.filterby_attr

--- a/docs/source/api/classes/xgi.classes.reportviews.EdgeView.rst
+++ b/docs/source/api/classes/xgi.classes.reportviews.EdgeView.rst
@@ -23,5 +23,6 @@ xgi.classes.reportviews.EdgeView
       ~EdgeView.members
       ~EdgeView.singletons
       ~IDView.neighbors
+      ~IDView.duplicates
       ~IDView.filterby
       ~IDView.filterby_attr

--- a/docs/source/api/classes/xgi.classes.reportviews.IDView.rst
+++ b/docs/source/api/classes/xgi.classes.reportviews.IDView.rst
@@ -19,5 +19,6 @@ xgi.classes.reportviews.IDView
       ~IDView.from_view
       ~IDView.neighbors
       ~IDView.duplicates
+      ~IDView.lookup
       ~IDView.filterby
       ~IDView.filterby_attr

--- a/docs/source/api/classes/xgi.classes.reportviews.IDView.rst
+++ b/docs/source/api/classes/xgi.classes.reportviews.IDView.rst
@@ -18,5 +18,6 @@ xgi.classes.reportviews.IDView
 
       ~IDView.from_view
       ~IDView.neighbors
+      ~IDView.duplicates
       ~IDView.filterby
       ~IDView.filterby_attr

--- a/docs/source/api/classes/xgi.classes.reportviews.NodeView.rst
+++ b/docs/source/api/classes/xgi.classes.reportviews.NodeView.rst
@@ -24,5 +24,6 @@ xgi.classes.reportviews.NodeView
       ~NodeView.isolates
       ~IDView.neighbors
       ~IDView.duplicates
+      ~IDView.lookup
       ~IDView.filterby
       ~IDView.filterby_attr

--- a/docs/source/api/classes/xgi.classes.reportviews.NodeView.rst
+++ b/docs/source/api/classes/xgi.classes.reportviews.NodeView.rst
@@ -23,5 +23,6 @@ xgi.classes.reportviews.NodeView
       ~NodeView.memberships
       ~NodeView.isolates
       ~IDView.neighbors
+      ~IDView.duplicates
       ~IDView.filterby
       ~IDView.filterby_attr

--- a/docs/source/api/classes/xgi.utils.utilities.rst
+++ b/docs/source/api/classes/xgi.utils.utilities.rst
@@ -14,5 +14,4 @@
 
    .. rubric:: Functions
 
-   .. autofunction:: convert_labels_to_integers
    .. autofunction:: dual_dict

--- a/tests/classes/test_function.py
+++ b/tests/classes/test_function.py
@@ -280,3 +280,50 @@ def test_is_empty():
     assert xgi.is_empty(H1)
     assert xgi.is_empty(H2)
     assert not xgi.is_empty(H3)
+
+
+def test_convert_labels_to_integers(hypergraph1, hypergraph2):
+    H1 = xgi.convert_labels_to_integers(hypergraph1)
+    H2 = xgi.convert_labels_to_integers(hypergraph2)
+    H3 = xgi.convert_labels_to_integers(hypergraph1, "old_ids")
+
+    assert set(H1.nodes) == {0, 1, 2}
+    assert set(H1.edges) == {0, 1, 2}
+
+    assert H1.nodes[0]["label"] == "a"
+    assert H1.nodes[1]["label"] == "b"
+    assert H1.nodes[2]["label"] == "c"
+
+    assert H1.edges[0]["label"] == "e1"
+    assert H1.edges[1]["label"] == "e2"
+    assert H1.edges[2]["label"] == "e3"
+
+    assert H1.edges.members(0) == [0, 1]
+    assert H1.edges.members(1) == [0, 1, 2]
+    assert H1.edges.members(2) == [2]
+
+    assert H1.nodes.memberships(0) == [0, 1]
+    assert H1.nodes.memberships(1) == [0, 1]
+    assert H1.nodes.memberships(2) == [1, 2]
+
+    assert set(H2.nodes) == {0, 1, 2}
+    assert set(H2.edges) == {0, 1, 2}
+
+    assert H2.nodes[0]["label"] == "b"
+    assert H2.nodes[1]["label"] == "c"
+    assert H2.nodes[2]["label"] == 0
+
+    assert H2.edges[0]["label"] == "e1"
+    assert H2.edges[1]["label"] == "e2"
+    assert H2.edges[2]["label"] == "e3"
+
+    assert H2.edges.members(0) == [2, 0]
+    assert H2.edges.members(1) == [2, 1]
+    assert H2.edges.members(2) == [2, 0, 1]
+
+    assert H2.nodes.memberships(0) == [0, 2]
+    assert H2.nodes.memberships(1) == [1, 2]
+    assert H2.nodes.memberships(2) == [0, 1, 2]
+
+    assert H3.nodes[0]["old_ids"] == "a"
+    assert H3.edges[0]["old_ids"] == "e1"

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -395,3 +395,13 @@ def test_double_edge_swap(edgelist1):
     # loopy swap
     H.double_edge_swap(4, 6, 0, 2)
     assert H.edges.members() == [[6, 2, 6], [3], [5, 4], [1, 7, 8]]
+
+
+def test_duplicate_edges(edgelist1):
+    H = xgi.Hypergraph(edgelist1)
+
+    H.add_edge([1, 3, 2])
+    assert list(H.edges.duplicates()) == [0, 4]
+
+    H.add_edge([1, 2, 3])
+    assert list(H.edges.duplicates()) == [0, 4, 5]

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -399,6 +399,7 @@ def test_double_edge_swap(edgelist1):
 
 def test_duplicate_edges(edgelist1):
     H = xgi.Hypergraph(edgelist1)
+    assert list(H.edges.duplicates()) == []
 
     H.add_edge([1, 3, 2])  # same order as existing edge
     assert list(H.edges.duplicates()) == [0, 4]
@@ -411,3 +412,19 @@ def test_duplicate_edges(edgelist1):
 
     H = xgi.Hypergraph([[1, 2, 3, 3], [3, 1, 2, 3]])  # repeated nodes
     assert list(H.edges.duplicates()) == [0, 1]
+
+
+def test_duplicate_nodes(edgelist1):
+    H = xgi.Hypergraph(edgelist1)
+    assert list(H.nodes.duplicates()) == [1, 2, 3, 7, 8]
+
+    H.add_edges_from([[1, 4], [2, 6, 7], [6, 8]])
+    assert list(H.nodes.duplicates()) == []
+
+    # this loop makes 1 and 2 belong to the same edges
+    for edgeid, members in H.edges.members(dtype=dict).items():
+        if 1 in members and 2 not in members:
+            H.add_node_to_edge(edgeid, 2)
+        if 1 not in members and 2 in members:
+            H.add_node_to_edge(edgeid, 1)
+    assert list(H.nodes.duplicates()) == [1, 2]

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -400,8 +400,14 @@ def test_double_edge_swap(edgelist1):
 def test_duplicate_edges(edgelist1):
     H = xgi.Hypergraph(edgelist1)
 
-    H.add_edge([1, 3, 2])
+    H.add_edge([1, 3, 2])  # same order as existing edge
     assert list(H.edges.duplicates()) == [0, 4]
 
-    H.add_edge([1, 2, 3])
+    H.add_edge([1, 2, 3])  # different order, same members
     assert list(H.edges.duplicates()) == [0, 4, 5]
+
+    H = xgi.Hypergraph([[1, 2, 3, 3], [1, 2, 3]])  # repeated nodes
+    assert list(H.edges.duplicates()) == []
+
+    H = xgi.Hypergraph([[1, 2, 3, 3], [3, 1, 2, 3]])  # repeated nodes
+    assert list(H.edges.duplicates()) == [0, 1]

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -141,16 +141,6 @@ def test_members(edgelist1):
         H.nodes.memberships(slice(1, 4))
 
 
-def test_has_edge(edgelist1):
-    H = xgi.Hypergraph(edgelist1)
-    assert H.has_edge([1, 2, 3])
-    assert H.has_edge({1, 2, 3})
-    assert H.has_edge({4})
-    assert not H.has_edge([4, 5])
-    assert not H.has_edge([3])
-    assert not H.has_edge([1, 2])
-
-
 def test_add_edge():
     for edge in [[1, 2, 3], {1, 2, 3}, iter([1, 2, 3])]:
         H = xgi.Hypergraph()

--- a/tests/classes/test_reportviews.py
+++ b/tests/classes/test_reportviews.py
@@ -233,6 +233,9 @@ def test_lookup(edgelist1):
     assert list(H.edges.lookup([4])) == [1]
     assert list(H.edges.lookup([1, 2])) == []
 
+    H = xgi.Hypergraph([["a", "b", "c"], ["a", "b", "e"], ["c", "d", "e"]])
+    assert set(H.nodes.lookup([0, 1])) == {"a", "b"}
+
 
 def test_bool(edgelist1):
     H = xgi.Hypergraph([])

--- a/tests/classes/test_reportviews.py
+++ b/tests/classes/test_reportviews.py
@@ -221,3 +221,21 @@ def test_singletons(edgelist1):
     H.remove_edge(1)
     assert 1 not in H.edges
     assert list(H.edges.singletons()) == []
+
+
+def test_lookup(edgelist1):
+    H = xgi.Hypergraph(edgelist1)
+    assert list(H.edges.lookup([1, 2, 3])) == [0]
+    assert list(H.edges.lookup({1, 2, 3})) == [0]
+    assert list(H.edges.lookup({4})) == [1]
+    assert list(H.edges.lookup([4, 5])) == []
+    assert list(H.edges.lookup([3])) == []
+    assert list(H.edges.lookup([4])) == [1]
+    assert list(H.edges.lookup([1, 2])) == []
+
+
+def test_bool(edgelist1):
+    H = xgi.Hypergraph([])
+    assert bool(H.edges) is False
+    H = xgi.Hypergraph(edgelist1)
+    assert bool(H.edges) is True

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,8 +1,8 @@
-from xgi.utils import convert_labels_to_integers, dual_dict
+import xgi
 
 
 def test_dual_dict(dict5):
-    dual = dual_dict(dict5)
+    dual = xgi.dual_dict(dict5)
     assert dual[0] == [0]
     assert dual[1] == [0]
     assert dual[2] == [0]
@@ -12,50 +12,3 @@ def test_dual_dict(dict5):
     assert dual[6] == [2, 3]
     assert dual[7] == [3]
     assert dual[8] == [3]
-
-
-def test_convert_labels_to_integers(hypergraph1, hypergraph2):
-    H1 = convert_labels_to_integers(hypergraph1)
-    H2 = convert_labels_to_integers(hypergraph2)
-    H3 = convert_labels_to_integers(hypergraph1, "old_ids")
-
-    assert set(H1.nodes) == {0, 1, 2}
-    assert set(H1.edges) == {0, 1, 2}
-
-    assert H1.nodes[0]["label"] == "a"
-    assert H1.nodes[1]["label"] == "b"
-    assert H1.nodes[2]["label"] == "c"
-
-    assert H1.edges[0]["label"] == "e1"
-    assert H1.edges[1]["label"] == "e2"
-    assert H1.edges[2]["label"] == "e3"
-
-    assert H1.edges.members(0) == [0, 1]
-    assert H1.edges.members(1) == [0, 1, 2]
-    assert H1.edges.members(2) == [2]
-
-    assert H1.nodes.memberships(0) == [0, 1]
-    assert H1.nodes.memberships(1) == [0, 1]
-    assert H1.nodes.memberships(2) == [1, 2]
-
-    assert set(H2.nodes) == {0, 1, 2}
-    assert set(H2.edges) == {0, 1, 2}
-
-    assert H2.nodes[0]["label"] == "b"
-    assert H2.nodes[1]["label"] == "c"
-    assert H2.nodes[2]["label"] == 0
-
-    assert H2.edges[0]["label"] == "e1"
-    assert H2.edges[1]["label"] == "e2"
-    assert H2.edges[2]["label"] == "e3"
-
-    assert H2.edges.members(0) == [2, 0]
-    assert H2.edges.members(1) == [2, 1]
-    assert H2.edges.members(2) == [2, 0, 1]
-
-    assert H2.nodes.memberships(0) == [0, 2]
-    assert H2.nodes.memberships(1) == [1, 2]
-    assert H2.nodes.memberships(2) == [0, 1, 2]
-
-    assert H3.nodes[0]["old_ids"] == "a"
-    assert H3.edges[0]["old_ids"] == "e1"

--- a/xgi/__init__.py
+++ b/xgi/__init__.py
@@ -1,24 +1,25 @@
 import pkg_resources
 
 from . import (
-    algorithms,
+    utils,
     classes,
+    algorithms,
     convert,
     drawing,
     generators,
     linalg,
     readwrite,
     stats,
-    utils,
 )
-from .algorithms import *
+from .utils import *
 from .classes import *
+from .algorithms import *
 from .convert import *
 from .drawing import *
 from .generators import *
 from .linalg import *
 from .readwrite import *
 from .stats import *
-from .utils import *
+
 
 __version__ = pkg_resources.require("xgi")[0].version

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -5,10 +5,9 @@ import numpy as np
 from numpy.linalg import norm
 from scipy.sparse.linalg import eigsh
 
-from ..classes import is_uniform
+from ..classes import is_uniform, convert_labels_to_integers
 from ..exception import XGIError
 from ..linalg import clique_motif_matrix, incidence_matrix
-from ..utils.utilities import convert_labels_to_integers
 
 __all__ = ["CEC_centrality", "HEC_centrality", "ZEC_centrality", "node_edge_centrality"]
 

--- a/xgi/classes/__init__.py
+++ b/xgi/classes/__init__.py
@@ -1,4 +1,4 @@
-from .function import *
 from .hypergraph import Hypergraph
+from .function import *
 from .hypergraphviews import subhypergraph
 from .simplicialcomplex import SimplicialComplex

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -3,6 +3,7 @@
 from collections import Counter
 
 from ..exception import XGIError
+from .hypergraph import Hypergraph
 
 __all__ = [
     "max_edge_order",
@@ -21,6 +22,7 @@ __all__ = [
     "get_edge_attributes",
     "is_empty",
     "maximal_simplices",
+    "convert_labels_to_integers",
 ]
 
 
@@ -613,3 +615,44 @@ def maximal_simplices(SC):
         if maximal:
             max_simplices.append(i)
     return max_simplices
+
+
+def convert_labels_to_integers(H, label_attribute="label"):
+    """Relabel node and edge IDs to be sequential integers.
+
+    Parameters
+    ----------
+    H : Hypergraph
+        The hypergraph of interest
+
+    label_attribute : string, default: "label"
+        The attribute name that stores the old node and edge labels
+
+    Returns
+    -------
+    Hypergraph
+        A new hypergraph with nodes and edges with sequential IDs starting at 0.
+        The old IDs are stored in the "label" attribute for both nodes and edges.
+
+    Notes
+    -----
+    The "relabeling" will occur even if the node/edge IDs are sequential.
+    Because the old IDs are stored in the "label" attribute for both nodes and edges,
+    the old "label" values (if they exist) will be overwritten.
+    """
+    node_dict = dict(zip(H.nodes, range(H.num_nodes)))
+    edge_dict = dict(zip(H.edges, range(H.num_edges)))
+    temp_H = Hypergraph()
+    temp_H._hypergraph = H._hypergraph.copy()
+
+    for node, id in node_dict.items():
+        temp_H._node[id] = [edge_dict[e] for e in H._node[node]]
+        temp_H._node_attr[id] = H._node_attr[node].copy()
+        temp_H._node_attr[id][label_attribute] = node
+
+    for edge, id in edge_dict.items():
+        temp_H._edge[id] = [node_dict[n] for n in H._edge[edge]]
+        temp_H._edge_attr[id] = H._edge_attr[edge].copy()
+        temp_H._edge_attr[id][label_attribute] = edge
+
+    return temp_H

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -950,16 +950,3 @@ class Hypergraph:
         dual._hypergraph = deepcopy(self._hypergraph)
 
         return dual
-
-    def duplicate_edges(self):
-        """A list of all duplicate edges.
-
-        Returns
-        -------
-        list
-            All edges with a duplicate.
-
-        """
-        edges = [tuple(e) for e in self._edge.values()]
-        edges_unique, counts = np.unique(edges, return_counts=True)
-        return list(edges_unique[np.where(counts > 1)])

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -368,32 +368,6 @@ class Hypergraph:
                 continue
             self.remove_node(n)
 
-    def has_edge(self, edge):
-        """Whether an edge is in the hypergraph.
-
-        Parameters
-        ----------
-        edge : Iterable
-            An iterable of hashables that specifies an edge by its member nodes.
-
-        Returns
-        -------
-        bool
-           Whether or not edge is as an edge in the hypergraph.
-
-        Examples
-        --------
-        >>> import xgi
-        >>> hyperedge_list = [[1, 2], [2, 3, 4]]
-        >>> H = xgi.Hypergraph(hyperedge_list)
-        >>> H.has_edge([1, 2])
-        True
-        >>> H.has_edge({1, 3})
-        False
-
-        """
-        return set(edge) in (set(self.edges.members(e)) for e in self.edges)
-
     def add_edge(self, members, id=None, **attr):
         """Add one edge with optional attributes.
 

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -355,13 +355,14 @@ class IDView(Mapping, Set):
         {2}
         >>> H.nodes.neighbors(2)
         {1, 3, 4}
+
         """
         return {i for n in self._id_dict[id] for i in self._bi_id_dict[n]}.difference(
             {id}
         )
 
     def duplicates(self):
-        """A view consisting of only those IDs of this view that have a duplicate.
+        """Find IDs that have a duplicate.
 
         An ID has a 'duplicate' if there exists another ID with the same bipartite
         neighbors.
@@ -375,6 +376,29 @@ class IDView(Mapping, Set):
         -----
         The IDs returned are in an arbitrary order, that is duplicates are not
         guaranteed to be consecutive.
+
+        See Also
+        --------
+        IDView.lookup
+
+        Examples
+        --------
+        >>> import xgi
+        >>> H = xgi.Hypergraph([[0, 1, 2], [3, 4, 2], [0, 1, 2]])
+        >>> H.edges.duplicates()
+        EdgeView((0, 2))
+
+        Order does not matter:
+
+        >>> H = xgi.Hypergraph([[0, 1, 2], [0, 1, 2]])
+        >>> H.edges.duplicates()
+        EdgeView((0, 1))
+
+        Repetitions matter:
+
+        >>> H = xgi.Hypergraph([[0, 1, 1], [1, 0, 1]])
+        >>> H.edges.duplicates()
+        EdgeView((0, 1))
 
         """
         dups = []

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -358,6 +358,39 @@ class IDView(Mapping, Set):
             {id}
         )
 
+    def duplicates(self):
+        """A view consisting of only those IDs of this view that have a duplicate.
+
+        An ID has a 'duplicate' if there exists another ID with the same bipartite
+        neighbors.
+
+        Returns
+        -------
+        IDView
+            A view containing only those IDs with a duplicate.
+
+        Notes
+        -----
+        The IDs returned are in an arbitrary order, that is duplicates are not
+        guaranteed to be consecutive.
+
+        """
+        dups = []
+        hashes = defaultdict(list)
+        for idx, members in self._id_dict.items():
+            hashes[frozenset(members)].append(idx)
+        for _, edges in hashes.items():
+            if len(edges) == 1:
+                continue
+            for edge1 in edges:
+                for edge2 in edges:
+                    if edge1 == edge2:
+                        continue
+                    if Counter(self._id_dict[edge1]) == Counter(self._id_dict[edge2]):
+                        dups.append(edge1)
+                        dups.append(edge2)
+        return self.__class__.from_view(self, bunch=dups)
+
     @classmethod
     def from_view(cls, view, bunch=None):
         """Create a view from another view.
@@ -375,7 +408,7 @@ class IDView(Mapping, Set):
         Returns
         -------
         IDView
-            A view object that is identical to `view` but keeps track of different IDs.
+            A view that is identical to `view` but keeps track of different IDs.
 
         """
         newview = cls(None)

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -393,6 +393,54 @@ class IDView(Mapping, Set):
                         dups.append(edge2)
         return self.__class__.from_view(self, bunch=dups)
 
+    def lookup(self, neighbors):
+        """Find IDs with the specified bipartite neighbors.
+
+        Parameters
+        ----------
+        neighbors : Iterable
+            An iterable of IDs.
+
+        Returns
+        -------
+        IDView
+            A view containing only those IDs whose bipartite neighbors match
+            `neighbors`.
+
+        See Also
+        --------
+        IDView.duplicates
+
+        Examples
+        --------
+        >>> import xgi
+        >>> H = xgi.Hypergraph([[0, 1, 2], [3, 4], [3, 4, 2]])
+        >>> H.edges.lookup([3, 4])
+        EdgeView((1,))
+        >>> H.add_edge([3, 4])
+        >>> H.edges.lookup([3, 4])
+        EdgeView((1, 3))
+
+        Can be used as a boolean check for edge existence:
+
+        >>> if H.edges.lookup([3, 4]): print('An edge with members [3, 4] exists')
+        An edge with members [3, 4] exists
+
+        Can also be used to check for nodes that belong to a particular set of edges:
+
+        >>> H = xgi.Hypergraph([['a', 'b', 'c'], ['a', 'b', 'd'], ['c', 'd', 'e']])
+        >>> H.nodes.lookup([0, 1])
+        NodeView(('a', 'b'))
+
+        """
+        sought = Counter(neighbors)
+        found = [
+            idx
+            for idx, neighbors in self._id_dict.items()
+            if Counter(neighbors) == sought
+        ]
+        return self.__class__.from_view(self, bunch=found)
+
     @classmethod
     def from_view(cls, view, bunch=None):
         """Create a view from another view.

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -5,10 +5,12 @@ allow modification.  This module provides View classes for nodes, edges, degree,
 edge size of a hypergraph.  Views are automatically updaed when the hypergraph changes.
 
 """
-from collections.abc import Mapping, Set
 
-from xgi.exception import IDNotFound, XGIError
-from xgi.stats import EdgeStatDispatcher, NodeStatDispatcher
+from collections.abc import Mapping, Set
+from collections import Counter, defaultdict
+
+from ..exception import IDNotFound, XGIError
+from ..stats import EdgeStatDispatcher, NodeStatDispatcher
 
 __all__ = [
     "NodeView",

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -452,9 +452,9 @@ class IDView(Mapping, Set):
 
         Can also be used to check for nodes that belong to a particular set of edges:
 
-        >>> H = xgi.Hypergraph([['a', 'b', 'c'], ['a', 'b', 'd'], ['c', 'd', 'e']])
+        >>> H = xgi.Hypergraph([['a', 'b', 'c'], ['a', 'd', 'e'], ['c', 'd', 'e']])
         >>> H.nodes.lookup([0, 1])
-        NodeView(('a', 'b'))
+        NodeView(('a',))
 
         """
         sought = Counter(neighbors)

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -1,9 +1,8 @@
 """General utilities."""
-from collections import defaultdict
 
-from ..classes import Hypergraph
+from collections import defaultdict, Counter
 
-__all__ = ["dual_dict", "convert_labels_to_integers"]
+__all__ = ["dual_dict"]
 
 
 def dual_dict(edge_dict):
@@ -36,44 +35,3 @@ def dual_dict(edge_dict):
             node_dict[node].append(edge_id)
 
     return dict(node_dict)
-
-
-def convert_labels_to_integers(H, label_attribute="label"):
-    """Relabel node and edge IDs to be sequential integers.
-
-    Parameters
-    ----------
-    H : Hypergraph
-        The hypergraph of interest
-
-    label_attribute : string, default: "label"
-        The attribute name that stores the old node and edge labels
-
-    Returns
-    -------
-    Hypergraph
-        A new hypergraph with nodes and edges with sequential IDs starting at 0.
-        The old IDs are stored in the "label" attribute for both nodes and edges.
-
-    Notes
-    -----
-    The "relabeling" will occur even if the node/edge IDs are sequential.
-    Because the old IDs are stored in the "label" attribute for both nodes and edges,
-    the old "label" values (if they exist) will be overwritten.
-    """
-    node_dict = dict(zip(H.nodes, range(H.num_nodes)))
-    edge_dict = dict(zip(H.edges, range(H.num_edges)))
-    temp_H = Hypergraph()
-    temp_H._hypergraph = H._hypergraph.copy()
-
-    for node, id in node_dict.items():
-        temp_H._node[id] = [edge_dict[e] for e in H._node[node]]
-        temp_H._node_attr[id] = H._node_attr[node].copy()
-        temp_H._node_attr[id][label_attribute] = node
-
-    for edge, id in edge_dict.items():
-        temp_H._edge[id] = [node_dict[n] for n in H._edge[edge]]
-        temp_H._edge_attr[id] = H._edge_attr[edge].copy()
-        temp_H._edge_attr[id][label_attribute] = edge
-
-    return temp_H


### PR DESCRIPTION
Final PR regarding #94 .

1. `Hypergraph.has_edge` has become `IDView.lookup`.
2. `Hypergraph.duplicate_edges` has been become `IDView.duplicates`.
3. I had to move `utilities.convert_labels_to_integer` to `function.convert_labels_to_integer` due to relative import weirdness.
4. A `IDView` behaves like a list when coercing it to bool (for example we can do `if view: ...`, and `view` will evaluate to `False` if it is empty). This was already implemented, but I added a test for it.

Closes #94.
Closes #93.