### PR TITLE
Implement computation of moments for NodeStat and EdgeStat

### DIFF
--- a/docs/source/api/stats/xgi.stats.EdgeStat.rst
+++ b/docs/source/api/stats/xgi.stats.EdgeStat.rst
@@ -21,13 +21,15 @@
    .. autosummary::
       :nosignatures:
 
-      ~NodeStat.asdict
-      ~NodeStat.aslist
-      ~NodeStat.asnumpy
-      ~NodeStat.aspandas
-      ~NodeStat.max
-      ~NodeStat.mean
-      ~NodeStat.median
-      ~NodeStat.min
-      ~NodeStat.std
-      ~NodeStat.var
+      ~EdgeStat.asdict
+      ~EdgeStat.aslist
+      ~EdgeStat.asnumpy
+      ~EdgeStat.aspandas
+      ~EdgeStat.max
+      ~EdgeStat.mean
+      ~EdgeStat.median
+      ~EdgeStat.min
+      ~EdgeStat.std
+      ~EdgeStat.var
+      ~EdgeStat.moment
+      ~EdgeStat.moment2

--- a/docs/source/api/stats/xgi.stats.NodeStat.rst
+++ b/docs/source/api/stats/xgi.stats.NodeStat.rst
@@ -31,3 +31,5 @@
       ~NodeStat.min
       ~NodeStat.std
       ~NodeStat.var
+      ~NodeStat.moment
+      ~NodeStat.moment2

--- a/tests/stats/test_nodestats.py
+++ b/tests/stats/test_nodestats.py
@@ -542,3 +542,21 @@ def test_view_val(edgelist1, edgelist2):
     H = xgi.Hypergraph(edgelist2)
     assert H.nodes.degree._val == {1: 1, 2: 1, 3: 1, 4: 2, 5: 1, 6: 1}
     assert H.nodes([4, 5, 6]).degree._val == {4: 2, 5: 1, 6: 1}
+
+
+def test_moment(edgelist1, edgelist6):
+    H = xgi.Hypergraph(edgelist1)
+    deg = H.nodes.degree
+    assert round(deg.moment2(), 3) == 1.375
+    assert round(deg.moment(2, center=False), 3) == 1.375
+    assert round(deg.moment(2, center=True), 3) == 0.109
+    assert round(deg.moment(3, center=False), 3) == 1.875
+    assert round(deg.moment(3, center=True), 3) == 0.082
+
+    H = xgi.Hypergraph(edgelist6)
+    deg = H.edges.size
+    assert round(deg.moment2(), 3) == 9.0
+    assert round(deg.moment(2, center=False), 3) == 9.0
+    assert round(deg.moment(2, center=True), 3) == 0.0
+    assert round(deg.moment(3, center=False), 3) == 27.0
+    assert round(deg.moment(3, center=True), 3) == 0.0

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -248,6 +248,13 @@ class IDStat:
         return self.asnumpy().var(axis=0)
 
     def moment2(self):
+        """The second uncentered moment of this stat.
+
+        Notes
+        -----
+        Convenience function, same as `self.moment(2, center=False)`.
+
+        """
         return self.moment(order=2, center=False)
 
     def moment(self, order, center=True):

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -49,6 +49,7 @@ from typing import Callable
 
 import numpy as np
 import pandas as pd
+from scipy.stats import moment as spmoment
 
 from xgi.exception import IDNotFound
 
@@ -245,6 +246,14 @@ class IDStat:
     def var(self):
         """The variance of this stat."""
         return self.asnumpy().var(axis=0)
+
+    def moment2(self):
+        return self.moment(order=2, center=False)
+
+    def moment(self, order, center=True):
+        """The statistical moments of this stat."""
+        arr = self.asnumpy()
+        return spmoment(arr, moment=order) if center else np.mean(arr ** order)
 
     def dist(self):
         return np.histogram(self.asnumpy(), density=True)


### PR DESCRIPTION
Closes #149.

I decided to add the convenience function `moment2` since the often-used "second moment of the degree distribution" is actually **NOT** the statistical second moment. The former is uncentered, the latter is centered. So the default value of `center` in `IDView.moment` is set to `True`, which is NOT what the network scientist would expect. So instead of doing `H.nodes.degree.moment(2, False)`, we can just do `H.nodes.degree.moment2()`.