### PR TITLE
Implement categorical stats

### DIFF
--- a/tests/stats/test_nodestats.py
+++ b/tests/stats/test_nodestats.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 import xgi
-from xgi.exception import IDNotFound, XGIError
+from xgi.exception import IDNotFound, XGIError, StatKindError
 
 
 def test_filterby_wrong_stat():

--- a/tests/stats/test_nodestats.py
+++ b/tests/stats/test_nodestats.py
@@ -202,6 +202,25 @@ def test_attrs(hyperwithattrs, attr1, attr2, attr3, attr4, attr5):
     assert filtered.asdict() == {3: attr3}
 
 
+def test_attrs_categorical(hyperwithattrs):
+    H = hyperwithattrs
+    assert H.nodes.attrs("color").mode() == "blue"
+    assert H.nodes.attrs("color").mode("all") == ["blue", "red"]
+
+    with pytest.raises(StatKindError):
+        H.nodes.attrs("color").mean()
+    with pytest.raises(StatKindError):
+        H.nodes.attrs("name").min()
+    with pytest.raises(StatKindError):
+        H.nodes.attrs("name").max()
+    with pytest.raises(StatKindError):
+        H.nodes.attrs("name").std()
+    with pytest.raises(StatKindError):
+        H.nodes.attrs("name").var()
+    with pytest.raises(StatKindError):
+        H.nodes.attrs("name").median()
+
+
 def test_stats_are_views(edgelist1):
     H = xgi.Hypergraph(edgelist1)
     ns = H.nodes.degree

--- a/xgi/exception.py
+++ b/xgi/exception.py
@@ -8,3 +8,7 @@ class XGIError(XGIException):
 
 class IDNotFound(KeyError):
     """Raised when a node or edge is not in the hypergraph."""
+
+
+class StatKindError(TypeError):
+    """Raised when the kind of a IDStat creates a conflict."""

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -44,17 +44,22 @@ statistics.  For more details, see the `tutorial
 
 """
 
-from collections import defaultdict
 from typing import Callable
 
 import numpy as np
 import pandas as pd
 
-from xgi.exception import IDNotFound
+from xgi.exception import IDNotFound, StatKindError
 
+from . import statkinds
 from . import edgestats, nodestats
 
-__all__ = ["nodestat_func", "edgestat_func", "EdgeStatDispatcher", "NodeStatDispatcher"]
+__all__ = [
+    "nodestat_func",
+    "edgestat_func",
+    "EdgeStatDispatcher",
+    "NodeStatDispatcher",
+]
 
 
 class StatDispatcher:

--- a/xgi/stats/edgestats.py
+++ b/xgi/stats/edgestats.py
@@ -20,6 +20,8 @@ Examples
 
 import xgi
 
+from . import statkinds
+
 __all__ = [
     "attrs",
     "order",
@@ -101,6 +103,9 @@ def attrs(net, bunch, attr=None, missing=None):
         return {e: net._edge_attr[e] for e in bunch}
     else:
         raise ValueError('"attr" must be str or None')
+
+
+attrs.kind = statkinds.CATEGORICAL
 
 
 def order(net, bunch, degree=None):

--- a/xgi/stats/nodestats.py
+++ b/xgi/stats/nodestats.py
@@ -19,6 +19,7 @@ Examples
 """
 
 import xgi
+from . import statkinds
 
 __all__ = [
     "attrs",
@@ -110,6 +111,9 @@ def attrs(net, bunch, attr=None, missing=None):
         return {n: net._node_attr[n] for n in bunch}
     else:
         raise ValueError('"attr" must be str or None')
+
+
+attrs.kind = statkinds.CATEGORICAL
 
 
 def degree(net, bunch, order=None, weight=None):

--- a/xgi/stats/statkinds.py
+++ b/xgi/stats/statkinds.py
@@ -1,0 +1,17 @@
+"""Kinds of stats."""
+
+from enum import Enum, auto
+
+
+__all__ = [
+    "StatKinds",
+]
+
+
+class StatKinds(Enum):
+    CATEGORICAL = auto()
+    NUMERICAL = auto()
+
+
+CATEGORICAL = StatKinds.CATEGORICAL
+NUMERICAL = StatKinds.NUMERICAL


### PR DESCRIPTION
See #141.

1. Implements categorical and numerical stats. Numerical stats are exactly the same as the stats we already had. Categorical stats are the same EXCEPT that some methods now raise the exception `StatKindError` when making some computations. For example, trying to compute the min, max, std, var, median, or mean of a categorical stat raises this error.

2. Impelements `IDStat.mode` which can be computed for either numerical or categorical stats.

3. The default is for a stat to be numerical.
 
4. **For developers**: if you want to add a new categorical stat, just add the corresponding function to either the `nodestats` or `edgestats` module, and then set the attribute `kind` of that function to `statkinds.CATEGORICAL`. There is an example [here](https://github.com/ComplexGroupInteractions/xgi/pull/157/files#diff-b3629fd2bee61fbc225b06c9940f4f6507a061fedcbe8e4561ddac90892b04c2R116), which sets node attributes to categorical. If you want to add a new numerical stat, there is nothing new for you to do.

5. **For users**: when adding a new stat using the decorators `nodestat_func` or `edgestat_func`, use the new keyword argument `categorical` to `True`.

6. Adds tests.

Closes #141 .