### PR TITLE
new add method

### DIFF
--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -57,16 +57,16 @@ def test_contains(edgelist1):
     assert [1, 2, 3] not in H
 
 
-def test_add(edgelist1, edgelist2, hyperwithattrs):
+def test_lshift(edgelist1, edgelist2, hyperwithattrs):
     H1 = xgi.Hypergraph(edgelist1)
     H2 = xgi.Hypergraph(edgelist2)
     H3 = hyperwithattrs
-    H = H1 + H2
+    H = H1 << H2
     assert set(H.nodes) == {1, 2, 3, 4, 5, 6, 7, 8}
     assert H.num_edges == 7
     assert H.edges.members(0) == {1, 2, 3}
 
-    H = H1 + H2 + H3
+    H = H1 << H2 << H3
     assert set(H.nodes) == {1, 2, 3, 4, 5, 6, 7, 8}
     assert H.num_edges == 10
     assert H.nodes[1] == {"color": "red", "name": "horse"}

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -57,6 +57,22 @@ def test_contains(edgelist1):
     assert [1, 2, 3] not in H
 
 
+def test_add(edgelist1, edgelist2, hyperwithattrs):
+    H1 = xgi.Hypergraph(edgelist1)
+    H2 = xgi.Hypergraph(edgelist2)
+    H3 = hyperwithattrs
+    H = H1 + H2
+    assert set(H.nodes) == {1, 2, 3, 4, 5, 6, 7, 8}
+    assert H.num_edges == 7
+    assert H.edges.members(0) == {1, 2, 3}
+
+    H = H1 + H2 + H3
+    assert set(H.nodes) == {1, 2, 3, 4, 5, 6, 7, 8}
+    assert H.num_edges == 10
+    assert H.nodes[1] == {"color": "red", "name": "horse"}
+    assert H.edges.members(7) == {1, 2, 3}
+
+
 def test_string():
     H1 = xgi.Hypergraph()
     assert str(H1) == "Unnamed Hypergraph with 0 nodes and 0 hyperedges"

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -204,6 +204,42 @@ class Hypergraph:
 
         return func
 
+    def __add__(self, H2):
+        """Adds two hypergraphs together
+
+        Relabels all the edge IDs to preserve all the edges but
+        keeps the node labels the same.
+
+        Parameters
+        ----------
+        H2 : Hypergraph
+            The hypergraph to be added
+
+        Returns
+        -------
+        Hypergraph
+            The added hypergraph
+
+        Notes
+        -----
+        Addition is not quite commutative; the attributes of nodes and edges
+        may be overwritten depending on whether they are first or second
+        to be added. In addition, the edge IDs are assigned based on the order
+        in which the edges are added, but does not functionally change the
+        structure of the hypergraph.
+        """
+        tempH = Hypergraph()
+        tempH.add_edges_from(zip(self._edge.values(), self._edge_attr.values()))
+        tempH.add_nodes_from(zip(self._node.keys(), self._node_attr.values()))
+
+        tempH.add_edges_from(zip(H2._edge.values(), H2._edge_attr.values()))
+        tempH.add_nodes_from(zip(H2._node.keys(), H2._node_attr.values()))
+
+        tempH._hypergraph = deepcopy(self._hypergraph)
+        tempH._hypergraph.update(deepcopy(H2._hypergraph))
+
+        return tempH
+
     @property
     def nodes(self):
         """A :class:`NodeView` of this network."""

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -204,8 +204,11 @@ class Hypergraph:
 
         return func
 
-    def __add__(self, H2):
-        """Adds two hypergraphs together
+    def __lshift__(self, H2):
+        """Adds the edges of a hypergraph to the current hypergraph
+        and updates the attributes.
+
+        The node/edge attributes of the new hypergraph take precedence.
 
         Relabels all the edge IDs to preserve all the edges but
         keeps the node labels the same.
@@ -213,12 +216,12 @@ class Hypergraph:
         Parameters
         ----------
         H2 : Hypergraph
-            The hypergraph to be added
+            The hypergraph to update with.
 
         Returns
         -------
         Hypergraph
-            The added hypergraph
+            The updated hypergraph
 
         Notes
         -----
@@ -227,6 +230,16 @@ class Hypergraph:
         to be added. In addition, the edge IDs are assigned based on the order
         in which the edges are added, but does not functionally change the
         structure of the hypergraph.
+
+        Examples
+        --------
+
+        >>> import xgi
+        >>> H1 = xgi.Hypergraph([[1, 2], [2, 3]])
+        >>> H2 = xgi.Hypergraph([[1, 3, 4]])
+        >>> H = H1 << H2
+        >>> H.edges.members()
+        [{1, 2}, {2, 3}, {1, 3, 4}]
         """
         tempH = Hypergraph()
         tempH.add_edges_from(zip(self._edge.values(), self._edge_attr.values()))

--- a/xgi/generators/classic.py
+++ b/xgi/generators/classic.py
@@ -13,9 +13,8 @@ import networkx as nx
 import numpy as np
 
 from ..classes import SimplicialComplex
-from ..utils import py_random_state
-
 from ..exception import XGIError
+from ..utils import py_random_state
 
 __all__ = [
     "empty_hypergraph",


### PR DESCRIPTION
Allows users to add two hypergraphs together. This reindexes all edges and keeps them all.