### PR TITLE
Remove dispatcher classes

### DIFF
--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -40,7 +40,10 @@ class IDView(Mapping, Set):
 
     """
 
+    dispatcherclass = None
+
     __slots__ = (
+        "_net",
         "_dispatcher",
         "_id_dict",
         "_id_attr",
@@ -83,11 +86,9 @@ class IDView(Mapping, Set):
         self._bi_id_attr = state["_bi_id_attr"]
         self._ids = state["_ids"]
 
-    def __init__(
-        self, network, id_dict, id_attr, bi_id_dict, bi_id_attr, dispatcher, ids=None
-    ):
+    def __init__(self, network, id_dict, id_attr, bi_id_dict, bi_id_attr, ids=None):
         self._net = network
-        self._dispatcher = dispatcher
+        self._dispatcher = self.dispatcherclass()
         self._id_dict = id_dict
         self._id_attr = id_attr
         self._bi_id_dict = bi_id_dict
@@ -526,14 +527,13 @@ class NodeView(IDView):
 
     """
 
+    dispatcherclass = NodeStatDispatcher
+
     def __init__(self, H, bunch=None):
-        dispatcher = NodeStatDispatcher()
         if H is None:
-            super().__init__(None, None, None, None, None, dispatcher, bunch)
+            super().__init__(None, None, None, None, None, bunch)
         else:
-            super().__init__(
-                H, H._node, H._node_attr, H._edge, H._edge_attr, dispatcher, bunch
-            )
+            super().__init__(H, H._node, H._node_attr, H._edge, H._edge_attr, bunch)
 
     def memberships(self, n=None):
         """Get the edge ids of which a node is a member.
@@ -619,14 +619,13 @@ class EdgeView(IDView):
 
     """
 
+    dispatcherclass = EdgeStatDispatcher
+
     def __init__(self, H, bunch=None):
-        dispatcher = EdgeStatDispatcher()
         if H is None:
-            super().__init__(None, None, None, None, None, dispatcher, bunch)
+            super().__init__(None, None, None, None, None, bunch)
         else:
-            super().__init__(
-                H, H._edge, H._edge_attr, H._node, H._node_attr, dispatcher, bunch
-            )
+            super().__init__(H, H._edge, H._edge_attr, H._node, H._node_attr, bunch)
 
     def members(self, e=None, dtype=list):
         """Get the node ids that are members of an edge.

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -96,7 +96,9 @@ class IDView(Mapping, Set):
             self._ids = ids
 
     def __getattr__(self, attr):
-        return getattr(self._dispatcher, attr)
+        stat = getattr(self._dispatcher, attr)
+        self.__dict__[attr] = stat
+        return stat
 
     @property
     def ids(self):

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -68,21 +68,19 @@ class StatDispatcher:
 
     """
 
-    def __init__(self, network, view, module, statsclass, multistatsclass):
-        self.net = network
-        self.view = view
+    def __init__(self, module, statsclass, multistatsclass):
         self.module = module
         self.statsclass = statsclass
         self.multistatsclass = multistatsclass
 
-    def __getattr__(self, name):
+    def dispatch(self, net, view, name):
         try:
             func = getattr(self.module, name)
         except AttributeError as e:
             raise AttributeError(f"Stat '{name}' not defined") from e
-        return self.statsclass(self.net, self.view, func)
+        return self.statsclass(net, view, func)
 
-    def multi(self, stats):
+    def dispatch_many_stats(self, net, view, stats):
         """Create a :class:`MultiStat` object.
 
         See Also
@@ -96,7 +94,7 @@ class StatDispatcher:
         <https://github.com/ComplexGroupInteractions/xgi/blob/main/tutorials/Tutorial%206%20-%20Statistics.ipynb>`_.
 
         """
-        return self.multistatsclass(self.net, self.view, stats)
+        return self.multistatsclass(net, view, stats)
 
 
 class EdgeStatDispatcher(StatDispatcher):
@@ -109,8 +107,8 @@ class EdgeStatDispatcher(StatDispatcher):
 
     """
 
-    def __init__(self, network, view):
-        super().__init__(network, view, edgestats, EdgeStat, MultiEdgeStat)
+    def __init__(self):
+        super().__init__(edgestats, EdgeStat, MultiEdgeStat)
 
 
 class NodeStatDispatcher(StatDispatcher):
@@ -123,8 +121,8 @@ class NodeStatDispatcher(StatDispatcher):
 
     """
 
-    def __init__(self, network, view):
-        super().__init__(network, view, nodestats, NodeStat, MultiNodeStat)
+    def __init__(self):
+        super().__init__(nodestats, NodeStat, MultiNodeStat)
 
 
 class IDStat:

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -80,9 +80,7 @@ class StatDispatcher:
             func = getattr(self.module, name)
         except AttributeError as e:
             raise AttributeError(f"Stat '{name}' not defined") from e
-        stat = self.statsclass(self.net, self.view, func)
-        self.__dict__[name] = stat
-        return stat
+        return self.statsclass(self.net, self.view, func)
 
     def multi(self, stats):
         """Create a :class:`MultiStat` object.
@@ -263,7 +261,7 @@ class IDStat:
 
         """
         arr = self.asnumpy()
-        return spmoment(arr, moment=order) if center else np.mean(arr**order)
+        return spmoment(arr, moment=order) if center else np.mean(arr ** order)
 
     def dist(self):
         return np.histogram(self.asnumpy(), density=True)


### PR DESCRIPTION
As I was writing [this comment,](https://github.com/ComplexGroupInteractions/xgi/pull/202#issuecomment-1298113259) I realized that the current state of finding/creating/dispatching NodeStats is sorta ridiculous. So I decided to improve things.

1. This PR removes three (!) classes (`StatDispatcher` and its descendants), creates two functions instead (`stats.dispatch_stat` and `stats.dispatch_many_stats`).
2. As a result, the `IDView` classes no longer need to create and hold reference to a dispatcher object. 
3. On the other hand, `IDView` classes now need to hold a reference to the network itself, in the newly created instance variable `_net`.

The improvement is clear from the following benchmark. Note that this is measuring the time it takes to access `H.nodes.degree` on an **empty** network.

Before:
```python3
>>> import xgi
>>> import cProfile
>>> cProfile.run("H = xgi.Hypergraph(); [H.nodes.degree for i in range(1000000)]")
         3000017 function calls (3000016 primitive calls) in 0.854 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.530    0.530    0.850    0.850 <string>:1(<listcomp>)
        1    0.003    0.003    0.854    0.854 <string>:1(<module>)
        1    0.000    0.000    0.000    0.000 __init__.py:114(__init__)
        1    0.000    0.000    0.000    0.000 __init__.py:128(__init__)
        1    0.000    0.000    0.000    0.000 __init__.py:135(__init__)
        2    0.000    0.000    0.000    0.000 __init__.py:71(__init__)
        1    0.000    0.000    0.000    0.000 __init__.py:78(__getattr__)
        1    0.000    0.000    0.000    0.000 hypergraph.py:101(__init__)
  1000000    0.088    0.000    0.088    0.000 hypergraph.py:256(nodes)
        1    0.000    0.000    0.000    0.000 reportviews.py:520(__init__)
        1    0.000    0.000    0.000    0.000 reportviews.py:613(__init__)
        2    0.000    0.000    0.000    0.000 reportviews.py:86(__init__)
  1000000    0.157    0.000    0.233    0.000 reportviews.py:98(__getattr__)
        1    0.000    0.000    0.854    0.854 {built-in method builtins.exec}
1000001/1000000    0.076    0.000    0.076    0.000 {built-in method builtins.getattr}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
        1    0.000    0.000    0.000    0.000 {method 'update' of 'dict' objects}
```

After this PR:
```python3
>>> import xgi
>>> import cProfile
>>> cProfile.run("H = xgi.Hypergraph(); [H.nodes.degree for i in range(1000000)]")
         1000014 function calls in 0.285 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.193    0.193    0.282    0.282 <string>:1(<listcomp>)
        1    0.003    0.003    0.285    0.285 <string>:1(<module>)
        1    0.000    0.000    0.000    0.000 __init__.py:425(dispatch_stat)
        1    0.000    0.000    0.000    0.000 __init__.py:64(__init__)
        1    0.000    0.000    0.000    0.000 hypergraph.py:101(__init__)
  1000000    0.089    0.000    0.089    0.000 hypergraph.py:256(nodes)
        1    0.000    0.000    0.000    0.000 reportviews.py:100(__getattr__)
        1    0.000    0.000    0.000    0.000 reportviews.py:529(__init__)
        1    0.000    0.000    0.000    0.000 reportviews.py:621(__init__)
        2    0.000    0.000    0.000    0.000 reportviews.py:88(__init__)
        1    0.000    0.000    0.285    0.285 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
        1    0.000    0.000    0.000    0.000 {method 'update' of 'dict' objects}
```

This is a 3x improvement in the time it takes to **access an attribute!**.

Technical note: the way that things used to work is that a `NodeView` object would create and hold reference to a `NodeStatDispatcher` object. Then, whenever a `NodeStat` was requested, say by executing `H.nodes.degree`, the `NodeView` would rely on the `NodeStatDispatcher` to find and create the corresponding `NodeStat` object. After this PR, this is no longer the case, and `NodeStat` just calls the `dispatch_stat` function instead. No need for middle-men dispatcher classes!