### PR TITLE
Hotfix 214

### DIFF
--- a/docs/source/api/classes/xgi.classes.function.rst
+++ b/docs/source/api/classes/xgi.classes.function.rst
@@ -27,4 +27,5 @@
    .. autofunction:: num_edges_order
    .. autofunction:: set_edge_attributes
    .. autofunction:: set_node_attributes
+   .. autofunction:: subfaces
    .. autofunction:: unique_edge_sizes

--- a/docs/source/api/classes/xgi.utils.utilities.rst
+++ b/docs/source/api/classes/xgi.utils.utilities.rst
@@ -15,3 +15,4 @@
    .. rubric:: Functions
 
    .. autofunction:: dual_dict
+   .. autofunction:: powerset

--- a/tests/classes/test_function.py
+++ b/tests/classes/test_function.py
@@ -720,3 +720,28 @@ def test_incidence_density(edgelist1):
     assert abs(dens_ignore_sing(7) - 1 / 3) < tol
     with pytest.raises(ValueError):
         xgi.incidence_density(H, max_order=8, ignore_singletons=True)
+
+
+def test_subfaces(edgelist5):
+
+    assert xgi.subfaces(edgelist5) == [(0,), (1,), (2,), (3,), 
+                                        (0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3),
+                                         (0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3),
+                                          (5,), (6,), (8,), (6,), (7,), (8, 6), (8, 7), (6, 7)]
+
+    assert xgi.subfaces(edgelist5, order=-1) == [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3),
+                                                 (5,), (6,), (8, 6), (8, 7), (6, 7)]
+
+    assert xgi.subfaces(edgelist5, order=0) == [(0,), (1,), (2,), (3,), (5,), (6,), (8,), (6,), (7,)]
+
+    assert xgi.subfaces(edgelist5, order=1) == [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3), (5, 6),
+                                                 (8, 6), (8, 7), (6, 7)]
+
+    assert xgi.subfaces(edgelist5, order=2) == [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3), (8, 6, 7)]
+    
+    assert xgi.subfaces(edgelist5, order=3) == [(0, 1, 2, 3)]
+
+    with pytest.raises(XGIError):
+        xgi.subfaces(edgelist5, order=4)  # order cannot be larger than maximum order in edgelist
+                                           
+

--- a/tests/classes/test_function.py
+++ b/tests/classes/test_function.py
@@ -724,24 +724,79 @@ def test_incidence_density(edgelist1):
 
 def test_subfaces(edgelist5):
 
-    assert xgi.subfaces(edgelist5) == [(0,), (1,), (2,), (3,), 
-                                        (0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3),
-                                         (0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3),
-                                          (5,), (6,), (8,), (6,), (7,), (8, 6), (8, 7), (6, 7)]
+    assert xgi.subfaces(edgelist5) == [
+        (0,),
+        (1,),
+        (2,),
+        (3,),
+        (0, 1),
+        (0, 2),
+        (0, 3),
+        (1, 2),
+        (1, 3),
+        (2, 3),
+        (0, 1, 2),
+        (0, 1, 3),
+        (0, 2, 3),
+        (1, 2, 3),
+        (5,),
+        (6,),
+        (8,),
+        (6,),
+        (7,),
+        (8, 6),
+        (8, 7),
+        (6, 7),
+    ]
 
-    assert xgi.subfaces(edgelist5, order=-1) == [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3),
-                                                 (5,), (6,), (8, 6), (8, 7), (6, 7)]
+    assert xgi.subfaces(edgelist5, order=-1) == [
+        (0, 1, 2),
+        (0, 1, 3),
+        (0, 2, 3),
+        (1, 2, 3),
+        (5,),
+        (6,),
+        (8, 6),
+        (8, 7),
+        (6, 7),
+    ]
 
-    assert xgi.subfaces(edgelist5, order=0) == [(0,), (1,), (2,), (3,), (5,), (6,), (8,), (6,), (7,)]
+    assert xgi.subfaces(edgelist5, order=0) == [
+        (0,),
+        (1,),
+        (2,),
+        (3,),
+        (5,),
+        (6,),
+        (8,),
+        (6,),
+        (7,),
+    ]
 
-    assert xgi.subfaces(edgelist5, order=1) == [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3), (5, 6),
-                                                 (8, 6), (8, 7), (6, 7)]
+    assert xgi.subfaces(edgelist5, order=1) == [
+        (0, 1),
+        (0, 2),
+        (0, 3),
+        (1, 2),
+        (1, 3),
+        (2, 3),
+        (5, 6),
+        (8, 6),
+        (8, 7),
+        (6, 7),
+    ]
 
-    assert xgi.subfaces(edgelist5, order=2) == [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3), (8, 6, 7)]
-    
+    assert xgi.subfaces(edgelist5, order=2) == [
+        (0, 1, 2),
+        (0, 1, 3),
+        (0, 2, 3),
+        (1, 2, 3),
+        (8, 6, 7),
+    ]
+
     assert xgi.subfaces(edgelist5, order=3) == [(0, 1, 2, 3)]
 
     with pytest.raises(XGIError):
-        xgi.subfaces(edgelist5, order=4)  # order cannot be larger than maximum order in edgelist
-                                           
-
+        xgi.subfaces(
+            edgelist5, order=4
+        )  # order cannot be larger than maximum order in edgelist

--- a/tests/generators/test_classic.py
+++ b/tests/generators/test_classic.py
@@ -56,6 +56,11 @@ def test_flag_complex():
     assert S2.edges.members() == simplices_2
     assert S3.edges.members() == simplices_2
 
+    G1 = nx.complete_graph(4)
+    S4 = xgi.flag_complex(G1)
+    S5 = xgi.flag_complex(G1, ps=[1])
+    assert S4.edges.members() == S5.edges.members()
+
 
 def test_ring_lattice():
     H = xgi.ring_lattice(5, 2, 2, 0)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -13,6 +13,7 @@ def test_dual_dict(dict5):
     assert dual[7] == [3]
     assert dual[8] == [3]
 
+
 def test_powerset():
 
     edge = [1, 2, 3, 4]
@@ -21,8 +22,22 @@ def test_powerset():
     PS1 = xgi.powerset(edge, include_empty=True)
     PS2 = xgi.powerset(edge, include_empty=True, include_full=True)
 
-    out = [(1,), (2,), (3,), (4,), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4),
-     (3, 4), (1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]
+    out = [
+        (1,),
+        (2,),
+        (3,),
+        (4,),
+        (1, 2),
+        (1, 3),
+        (1, 4),
+        (2, 3),
+        (2, 4),
+        (3, 4),
+        (1, 2, 3),
+        (1, 2, 4),
+        (1, 3, 4),
+        (2, 3, 4),
+    ]
 
     assert list(PS) == out
     assert list(PS1) == [()] + out

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -12,3 +12,18 @@ def test_dual_dict(dict5):
     assert dual[6] == [2, 3]
     assert dual[7] == [3]
     assert dual[8] == [3]
+
+def test_powerset():
+
+    edge = [1, 2, 3, 4]
+
+    PS = xgi.powerset(edge)
+    PS1 = xgi.powerset(edge, include_empty=True)
+    PS2 = xgi.powerset(edge, include_empty=True, include_full=True)
+
+    out = [(1,), (2,), (3,), (4,), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4),
+     (3, 4), (1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]
+
+    assert list(PS) == out
+    assert list(PS1) == [()] + out
+    assert list(PS2) == [()] + out + [tuple(edge)]

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -866,6 +866,28 @@ def subfaces(edges, order=None):
     faces: list of sets
         List of hyperedges that are subfaces of input hyperedges
 
+    Notes
+    -----
+    Hyperedges in the returned list are not unique, they may appear more than once
+    if they are subfaces or more than one edge from the input edges.
+
+    Raises
+    ------
+    XGIError
+        Raises error when order is larger than the max order of input edges
+
+    Examples
+    --------
+    >>> import xgi
+    >>> edges = [{1,2,3,4}, {3,4,5}]
+    >>> xgi.subfaces(edges) # doctest: +NORMALIZE_WHITESPACE
+    [(1,), (2,), (3,), (4,), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4), (1, 2, 3),
+     (1, 2, 4), (1, 3, 4), (2, 3, 4), (3,), (4,), (5,), (3, 4), (3, 5), (4, 5)]
+    >>> xgi.subfaces(edges, order=-1)
+    [(1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4), (3, 4), (3, 5), (4, 5)]
+    >>> xgi.subfaces(edges, order=2)
+    [(1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4), (3, 4, 5)]
+
     """
 
     max_order = len(max(edges, key=len)) - 1

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -864,17 +864,17 @@ def subfaces(edges, order=None):
     Returns
     -------
     faces: list of sets
-        List of hyperedges that are subfaces of input hyperedges
-
-    Notes
-    -----
-    Hyperedges in the returned list are not unique, they may appear more than once
-    if they are subfaces or more than one edge from the input edges.
+        List of hyperedges that are subfaces of input hyperedges.
 
     Raises
     ------
     XGIError
         Raises error when order is larger than the max order of input edges
+
+    Notes
+    -----
+    Hyperedges in the returned list are not unique, they may appear more than once
+    if they are subfaces or more than one edge from the input edges.
 
     Examples
     --------

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -3,8 +3,9 @@
 from collections import Counter
 from copy import deepcopy
 from itertools import combinations
-from scipy.special import comb
 from warnings import warn
+
+from scipy.special import comb
 
 from ..exception import IDNotFound, XGIError
 from ..utils.utilities import powerset
@@ -753,7 +754,7 @@ def density(H, order=None, max_order=None, ignore_singletons=False):
 
     if order is None and max_order is None:
         numer = H.num_edges
-        denom = 2 ** n - 1
+        denom = 2**n - 1
         if ignore_singletons:
             numer -= len(order_filter(0, mode="eq"))
             denom -= n
@@ -859,32 +860,34 @@ def subfaces(edges, order=None):
         If None, compute subfaces recursively down to nodes.
         If -1, compute subfaces the order below (e.g. edges for a triangle).
         If d > 0, compute the subfaces of order d.
-    
+
     Returns
     -------
     faces: list of sets
         List of hyperedges that are subfaces of input hyperedges
 
     """
-    
+
     max_order = len(max(edges, key=len)) - 1
     if order and order > max_order:
-        raise XGIError(f"order must be less or equal to the maximum order among the edges: {max_order}.")
+        raise XGIError(
+            f"order must be less or equal to the maximum order among the edges: {max_order}."
+        )
 
     faces = []
-    for edge in edges: 
+    for edge in edges:
         size = len(edge)
 
-        if size<=1: # down from a node is an empty tuple
+        if size <= 1:  # down from a node is an empty tuple
             continue
 
-        if order is None: # add all subfaces down to nodes
+        if order is None:  # add all subfaces down to nodes
             faces_to_add = list(powerset(edge))
-        elif order==-1: # add subfaces of order below
-            
+        elif order == -1:  # add subfaces of order below
+
             faces_to_add = list(combinations(edge, size - 1))
-        elif order>=0: # add subfaces of order d
-            faces_to_add = list(combinations(edge, order+1))
+        elif order >= 0:  # add subfaces of order d
+            faces_to_add = list(combinations(edge, order + 1))
 
         faces += faces_to_add
     return faces

--- a/xgi/classes/function.py
+++ b/xgi/classes/function.py
@@ -31,6 +31,7 @@ __all__ = [
     "convert_labels_to_integers",
     "density",
     "incidence_density",
+    "subfaces",
 ]
 
 
@@ -868,15 +869,19 @@ def subfaces(edges, order=None):
     
     max_order = len(max(edges, key=len)) - 1
     if order and order > max_order:
-        raise XGIError(f"order must be less or equal to the maximum order of among the edges {max_order}.")
+        raise XGIError(f"order must be less or equal to the maximum order among the edges: {max_order}.")
 
     faces = []
     for edge in edges: 
         size = len(edge)
 
+        if size<=1: # down from a node is an empty tuple
+            continue
+
         if order is None: # add all subfaces down to nodes
             faces_to_add = list(powerset(edge))
         elif order==-1: # add subfaces of order below
+            
             faces_to_add = list(combinations(edge, size - 1))
         elif order>=0: # add subfaces of order d
             faces_to_add = list(combinations(edge, order+1))

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Set
 
 from ..exception import IDNotFound, XGIError
-from ..stats import IDStat, dispatch_stat, dispatch_many_stats
+from ..stats import IDStat, dispatch_many_stats, dispatch_stat
 
 __all__ = [
     "NodeView",

--- a/xgi/generators/classic.py
+++ b/xgi/generators/classic.py
@@ -221,9 +221,9 @@ def flag_complex(G, max_order=2, ps=None, seed=None):
         S.add_simplices_from(max_cliques, max_order=max_order)
         return S
 
-    if max_order: # compute subfaces of order max_order (allowed max cliques)
+    if max_order:  # compute subfaces of order max_order (allowed max cliques)
         max_cliques_to_add = subfaces(max_cliques, order=max_order)
-    else: 
+    else:
         max_cliques_to_add = max_cliques
 
     # store max cliques per order

--- a/xgi/generators/classic.py
+++ b/xgi/generators/classic.py
@@ -12,7 +12,7 @@ from warnings import warn
 import networkx as nx
 import numpy as np
 
-from ..classes import SimplicialComplex
+from ..classes.function import subfaces
 from ..exception import XGIError
 from ..utils import py_random_state
 
@@ -206,11 +206,12 @@ def flag_complex(G, max_order=2, ps=None, seed=None):
     """
     # This import needs to happen when this function is called, not when it is
     # defined.  Otherwise, a circular import error would happen.
+    from ..classes import SimplicialComplex
 
     nodes = G.nodes()
     edges = G.edges()
 
-    # compute all cliques to fill
+    # compute all maximal cliques to fill
     max_cliques = list(nx.find_cliques(G))
 
     S = SimplicialComplex()
@@ -220,11 +221,17 @@ def flag_complex(G, max_order=2, ps=None, seed=None):
         S.add_simplices_from(max_cliques, max_order=max_order)
         return S
 
-    # promote cliques with a given probability
+    if max_order: # compute subfaces of order max_order (allowed max cliques)
+        max_cliques_to_add = subfaces(max_cliques, order=max_order)
+    else: 
+        max_cliques_to_add = max_cliques
+
+    # store max cliques per order
     cliques_d = defaultdict(list)
-    for x in max_cliques:
+    for x in max_cliques_to_add:
         cliques_d[len(x)].append(x)
 
+    # promote cliques with a given probability
     for i, p in enumerate(ps[: max_order - 1]):
         d = i + 2  # simplex order
         cliques_d_to_add = [el for el in cliques_d[d + 1] if seed.random() <= p]

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -192,7 +192,7 @@ class IDStat:
 
         """
         arr = self.asnumpy()
-        return spmoment(arr, moment=order) if center else np.mean(arr ** order)
+        return spmoment(arr, moment=order) if center else np.mean(arr**order)
 
     def dist(self):
         return np.histogram(self.asnumpy(), density=True)

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -57,7 +57,8 @@ def powerset(iterable, include_empty=False, include_full=False):
 
     Examples
     --------
-    >>> list(powerset([1,2,3,4])) # doctest: +NORMALIZE_WHITESPACE
+    >>> import xgi
+    >>> list(xgi.powerset([1,2,3,4])) # doctest: +NORMALIZE_WHITESPACE
     [(1,), (2,), (3,), (4,), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4),
      (1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]
 

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -1,6 +1,8 @@
 """General utilities."""
 
 from collections import defaultdict
+from itertools import chain, combinations
+
 
 __all__ = ["dual_dict", "powerset"]
 
@@ -55,7 +57,7 @@ def powerset(iterable, include_empty=False, include_full=False):
 
     Examples
     --------
-    >>> list(powerset([1,2,3,4]))
+    >>> list(powerset([1,2,3,4])) # doctest: +NORMALIZE_WHITESPACE
     [(1,), (2,), (3,), (4,), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4),
      (1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]
 

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -3,7 +3,6 @@
 from collections import defaultdict
 from itertools import chain, combinations
 
-
 __all__ = ["dual_dict", "powerset"]
 
 
@@ -38,9 +37,10 @@ def dual_dict(edge_dict):
 
     return dict(node_dict)
 
+
 def powerset(iterable, include_empty=False, include_full=False):
     """Returns all possible subsets of the elements in iterable, with options
-    to include the empty set and the set containing all elements. 
+    to include the empty set and the set containing all elements.
 
     Parameters
     ----------
@@ -74,4 +74,4 @@ def powerset(iterable, include_empty=False, include_full=False):
         end = 0
 
     s = list(iterable)
-    return chain.from_iterable(combinations(s, r) for r in range(start, len(s)+end))
+    return chain.from_iterable(combinations(s, r) for r in range(start, len(s) + end))

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 
-__all__ = ["dual_dict"]
+__all__ = ["dual_dict", "powerset"]
 
 
 def dual_dict(edge_dict):
@@ -35,3 +35,41 @@ def dual_dict(edge_dict):
             node_dict[node].append(edge_id)
 
     return dict(node_dict)
+
+def powerset(iterable, include_empty=False, include_full=False):
+    """Returns all possible subsets of the elements in iterable, with options
+    to include the empty set and the set containing all elements. 
+
+    Parameters
+    ----------
+    iterable : list-like
+        List of elements
+    include_empty: bool, default: False
+        Whether to include the empty set
+    include_full: bool, default: False
+        Whether to include the set containing all elements of iterable
+
+    Returns
+    -------
+    itertools.chain
+
+    Examples
+    --------
+    >>> list(powerset([1,2,3,4]))
+    [(1,), (2,), (3,), (4,), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4),
+     (1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]
+
+    """
+
+    if include_empty:
+        start = 0
+    else:
+        start = 1
+
+    if include_full:
+        end = 1
+    else:
+        end = 0
+
+    s = list(iterable)
+    return chain.from_iterable(combinations(s, r) for r in range(start, len(s)+end))

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -64,15 +64,8 @@ def powerset(iterable, include_empty=False, include_full=False):
 
     """
 
-    if include_empty:
-        start = 0
-    else:
-        start = 1
-
-    if include_full:
-        end = 1
-    else:
-        end = 0
+    start = 0 if include_empty else 1
+    end = 1 if include_full else 0
 
     s = list(iterable)
     return chain.from_iterable(combinations(s, r) for r in range(start, len(s) + end))


### PR DESCRIPTION
- fixed #214 : all simplices are added correctly with max_order now
- added a `powerset` function to compute all subsets of a set
- added a `subfaces` function. 
- added tests and examples for all the above, and included them in docs

The `subfaces` extends the current private `_subfaces` present in `SimplicialComplex.py` with a few options, and is available publicly. I think it should ultimately replace `_subfaces`. 