### PR TITLE
speedup add_simplices_from

### DIFF
--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -612,4 +612,4 @@ class SimplicialComplex(Hypergraph):
         False
 
         """
-        return frozenset(simplex) in (s for s in self._edge.values())
+        return frozenset(simplex) in self._edge.values()

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -612,4 +612,4 @@ class SimplicialComplex(Hypergraph):
         False
 
         """
-        return set(simplex) in (set(self.edges.members(s)) for s in self.edges)
+        return frozenset(simplex) in (s for s in self._edge.values())

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -38,7 +38,7 @@ def dual_dict(edge_dict):
     return dict(node_dict)
 
 
-def powerset(iterable, include_empty=False, include_full=False):
+def powerset(iterable, include_empty=False, include_full=False, include_singletons=True):
     """Returns all possible subsets of the elements in iterable, with options
     to include the empty set and the set containing all elements.
 
@@ -48,12 +48,19 @@ def powerset(iterable, include_empty=False, include_full=False):
         List of elements
     include_empty: bool, default: False
         Whether to include the empty set
+    include_singletons: bool, default: True
+        Whether to include singletons
     include_full: bool, default: False
         Whether to include the set containing all elements of iterable
 
     Returns
     -------
     itertools.chain
+
+    Notes
+    -----
+    include_empty overrides include_singletons if True: singletons will always
+    be included if the empty set is. 
 
     Examples
     --------
@@ -64,7 +71,8 @@ def powerset(iterable, include_empty=False, include_full=False):
 
     """
 
-    start = 0 if include_empty else 1
+    start = 1 if include_singletons else 2
+    start = 0 if include_empty else start # overrides include_singletons if True
     end = 1 if include_full else 0
 
     s = list(iterable)


### PR DESCRIPTION
`add_simplices_from` is slow, see #221. Profiling showed about 90% of the time is spent in the line checking existence of the simplex: 
```python
if not members or self.has_simplex(members):
```

`has_simplex()` now access members through `S._edge` rather than `S.edges.members(s)` which is significantly faster (see #221 for timings).

Here, adding 100 triangles seems about 10x faster:

```python
%timeit S.add_simplices_from(list(triangles)[:100]) 
# old -> 9.13 ms ± 28.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# new -> 860 µs ± 5.18 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

The `add_simplices_from` can probably be improved even more, by rewriting it it without recursion for example. I have written a version but not pushed it because the seped improvement seems negligible in my case (it might not be with larger simplices). Also, it modifies the method much more, so has a larger chance of new bugs. And it changes the order in which simplices are added, so tests would need to be udpated. I would start with this minimal update at first, and maybe use the other version for a second step. 