### PR TITLE
Fix for dynamical assortativity

### DIFF
--- a/tests/algorithms/test_assortativity.py
+++ b/tests/algorithms/test_assortativity.py
@@ -6,7 +6,7 @@ from xgi.algorithms.assortativity import choose_degrees
 from xgi.exception import XGIError
 
 
-def test_dynamical_assortativity(edgelist1, edgelist6):
+def test_dynamical_assortativity(edgelist1, edgelist6, edgelist9, edgelist10):
 
     H = xgi.Hypergraph()
     with pytest.raises(XGIError):
@@ -17,13 +17,21 @@ def test_dynamical_assortativity(edgelist1, edgelist6):
     with pytest.raises(XGIError):
         xgi.dynamical_assortativity(H)
 
+    # must be uniform
     with pytest.raises(XGIError):
-        H1 = xgi.Hypergraph(edgelist1)
-        xgi.dynamical_assortativity(H1)
+        H = xgi.Hypergraph(edgelist1)
+        xgi.dynamical_assortativity(H)
 
-    H1 = xgi.Hypergraph(edgelist6)
+    # no singleton edges
+    with pytest.raises(XGIError):
+        H = xgi.Hypergraph(edgelist10)
+        xgi.dynamical_assortativity(H)
 
-    assert abs(xgi.dynamical_assortativity(H1) - -0.0526) < 1e-3
+    H = xgi.Hypergraph(edgelist6)
+    assert abs(xgi.dynamical_assortativity(H) - -0.0526) < 1e-3
+
+    H = xgi.Hypergraph(edgelist9)
+    assert abs(xgi.dynamical_assortativity(H) - -0.0526) < 1e-3
 
 
 def test_degree_assortativity(edgelist1, edgelist5):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,16 @@ def edgelist8():
 
 
 @pytest.fixture
+def edgelist9():
+    return [{1, 2, 3}, {2, 3, 4}, {3, 4, 5}]
+
+
+@pytest.fixture
+def edgelist10():
+    return [{1}, {2}, {3}]
+
+
+@pytest.fixture
 def dict5():
     return {0: {0, 1, 2, 3}, 1: {4}, 2: {5, 6}, 3: {6, 7, 8}}
 

--- a/xgi/algorithms/assortativity.py
+++ b/xgi/algorithms/assortativity.py
@@ -4,8 +4,8 @@ from itertools import combinations
 
 import numpy as np
 
-import xgi
-from xgi.exception import XGIError
+from ..classes import is_uniform, unique_edge_sizes
+from ..exception import XGIError
 
 __all__ = ["dynamical_assortativity", "degree_assortativity"]
 
@@ -40,12 +40,16 @@ def dynamical_assortativity(H):
     if H.num_nodes == 0 or H.num_edges == 0:
         raise XGIError("Hypergraph must contain nodes and edges!")
 
-    if not xgi.is_uniform(H):
+    if not is_uniform(H):
         raise XGIError("Hypergraph must be uniform!")
 
-    degs = H.nodes.degree.asnumpy()
-    k1 = np.mean(degs)
-    k2 = np.mean(np.power(degs, 2))
+    if 1 in unique_edge_sizes(H):
+        raise XGIError("No singleton edges!")
+
+    d = H.nodes.degree
+    degs = d.asdict()
+    k1 = d.mean()
+    k2 = d.moment(2)
     kk1 = np.mean(
         [
             degs[n1] * degs[n2]


### PR DESCRIPTION
Formerly raised an error with nodes that did not have IDs that were sequential integers starting from zero. This is now fixed.