### PR TITLE
Added lost of tests for SimplicialComplex class

### DIFF
--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -1,5 +1,6 @@
 import pickle
 import tempfile
+from warnings import warn
 
 import pytest
 
@@ -189,7 +190,9 @@ def test_add_edge():
     H2 = xgi.Hypergraph()
     H2.add_edge([1, 2])
     H2.add_edge([3, 4])
-    H2.add_edge([5, 6], id=1)
+    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add edge {5, 6}"):
+        H2.add_edge([5, 6], id=0)
+  
     assert H2._edge == {0: {1, 2}, 1: {3, 4}}
 
 
@@ -234,10 +237,6 @@ def test_add_edges_from_iterable_of_members():
     H1 = xgi.Hypergraph(edges)
     with pytest.raises(XGIError):
         xgi.Hypergraph(H1.edges)
-
-    H = xgi.Hypergraph()
-    H.add_edges_from(edges)
-    assert H.edges.members() == edges
 
     edges = {frozenset([0, 1]), frozenset([1, 2]), frozenset([2, 3, 4])}
     H = xgi.Hypergraph()
@@ -286,7 +285,8 @@ def test_add_edges_from_format2():
     assert H.edges.members(101) == {1, 9, 2}
 
     H1 = xgi.Hypergraph([{1, 2}, {2, 3, 4}])
-    H1.add_edges_from([({1, 3}, 0)])
+    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add edge {1, 3}."):
+        H1.add_edges_from([({1, 3}, 0)])
     assert H1._edge == {0: {1, 2}, 1: {2, 3, 4}}
 
 
@@ -324,7 +324,8 @@ def test_add_edges_from_format4():
     assert H.edges.members(0) == {1, 9, 2}
 
     H1 = xgi.Hypergraph([{1, 2}, {2, 3, 4}])
-    H1.add_edges_from([({0, 1}, 0, {"color": "red"})])
+    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add edge {0, 1}."):
+        H1.add_edges_from([({0, 1}, 0, {"color": "red"})])
     assert H1._edge == {0: {1, 2}, 1: {2, 3, 4}}
 
 
@@ -339,7 +340,8 @@ def test_add_edges_from_dict():
     assert H.edges.members(3) == {1, 9, 2}
 
     H1 = xgi.Hypergraph([{1, 2}, {2, 3, 4}])
-    H1.add_edges_from({0: {1, 3}})
+    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add edge {1, 3}."):
+        H1.add_edges_from({0: {1, 3}})
     assert H1._edge == {0: {1, 2}, 1: {2, 3, 4}}
 
 

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -534,7 +534,8 @@ def test_merge_duplicate_edges(hyperwithdupsandattrs):
     assert H.edges.members(6) == {3, 4, 5}
 
     H = hyperwithdupsandattrs.copy()
-    H.merge_duplicate_edges(merge_rule="union", multiplicity="mult")
+    with pytest.warns(UserWarning, match="You will not be able to color/draw by merged attributes with xgi.draw()"):
+        H.merge_duplicate_edges(merge_rule="union", multiplicity="mult")
     assert H.edges[0] == {
         "color": {"blue", "red", "yellow"},
         "weight": {2, None},

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -190,9 +190,11 @@ def test_add_edge():
     H2 = xgi.Hypergraph()
     H2.add_edge([1, 2])
     H2.add_edge([3, 4])
-    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add edge {5, 6}"):
+    with pytest.warns(
+        UserWarning, match="uid 0 already exists, cannot add edge {5, 6}"
+    ):
         H2.add_edge([5, 6], id=0)
-  
+
     assert H2._edge == {0: {1, 2}, 1: {3, 4}}
 
 
@@ -285,7 +287,9 @@ def test_add_edges_from_format2():
     assert H.edges.members(101) == {1, 9, 2}
 
     H1 = xgi.Hypergraph([{1, 2}, {2, 3, 4}])
-    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add edge {1, 3}."):
+    with pytest.warns(
+        UserWarning, match="uid 0 already exists, cannot add edge {1, 3}."
+    ):
         H1.add_edges_from([({1, 3}, 0)])
     assert H1._edge == {0: {1, 2}, 1: {2, 3, 4}}
 
@@ -324,7 +328,9 @@ def test_add_edges_from_format4():
     assert H.edges.members(0) == {1, 9, 2}
 
     H1 = xgi.Hypergraph([{1, 2}, {2, 3, 4}])
-    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add edge {0, 1}."):
+    with pytest.warns(
+        UserWarning, match="uid 0 already exists, cannot add edge {0, 1}."
+    ):
         H1.add_edges_from([({0, 1}, 0, {"color": "red"})])
     assert H1._edge == {0: {1, 2}, 1: {2, 3, 4}}
 
@@ -340,7 +346,9 @@ def test_add_edges_from_dict():
     assert H.edges.members(3) == {1, 9, 2}
 
     H1 = xgi.Hypergraph([{1, 2}, {2, 3, 4}])
-    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add edge {1, 3}."):
+    with pytest.warns(
+        UserWarning, match="uid 0 already exists, cannot add edge {1, 3}."
+    ):
         H1.add_edges_from({0: {1, 3}})
     assert H1._edge == {0: {1, 2}, 1: {2, 3, 4}}
 
@@ -534,7 +542,10 @@ def test_merge_duplicate_edges(hyperwithdupsandattrs):
     assert H.edges.members(6) == {3, 4, 5}
 
     H = hyperwithdupsandattrs.copy()
-    with pytest.warns(UserWarning, match="You will not be able to color/draw by merged attributes with xgi.draw()"):
+    with pytest.warns(
+        UserWarning,
+        match="You will not be able to color/draw by merged attributes with xgi.draw()",
+    ):
         H.merge_duplicate_edges(merge_rule="union", multiplicity="mult")
     assert H.edges[0] == {
         "color": {"blue", "red", "yellow"},

--- a/tests/classes/test_simplicialcomplex.py
+++ b/tests/classes/test_simplicialcomplex.py
@@ -7,18 +7,25 @@ from xgi.exception import XGIError
 def test_constructor(edgelist5, dict5, incidence5, dataframe5):
     S_list = xgi.SimplicialComplex(edgelist5)
     S_df = xgi.SimplicialComplex(dataframe5)
+    S_sc = xgi.SimplicialComplex(S_list)
 
     with pytest.raises(XGIError):
         S_dict = xgi.SimplicialComplex(dict5)
     with pytest.raises(XGIError):
         S_mat = xgi.SimplicialComplex(incidence5)
 
-    assert set(S_list.nodes) == set(S_df.nodes)
-    assert set(S_list.edges) == set(S_df.edges)
-    assert set(S_list.edges.members(0)) == set(S_df.edges.members(0))
+    assert set(S_list.nodes) == set(S_df.nodes) == set(S_sc.nodes)
+    assert set(S_list.edges) == set(S_df.edges) == set(S_sc.edges)
+    assert set(S_list.edges.members(0)) == set(S_df.edges.members(0)) == set(S_sc.edges.members(0))
 
     with pytest.raises(XGIError):
         xgi.SimplicialComplex(1)
+
+def test_string():
+    S1 = xgi.SimplicialComplex()
+    assert str(S1) == "Unnamed SimplicialComplex with 0 nodes and 0 simplices"
+    S2 = xgi.SimplicialComplex(name="test")
+    assert str(S2) == "SimplicialComplex named 'test' with 0 nodes and 0 simplices"
 
 
 def test_add_simplex():

--- a/tests/classes/test_simplicialcomplex.py
+++ b/tests/classes/test_simplicialcomplex.py
@@ -107,6 +107,10 @@ def test_add_simplices_from(edgelist5):
     S6.add_simplices_from({0: {1, 3}})
     assert S6._edge == {0: frozenset({1, 2}), 1: frozenset({2, 3})}
 
+    S7 = xgi.SimplicialComplex()
+    S7.add_simplices_from([({0, 1, 2}, 0, {})])
+    assert S7._edge == {0: frozenset({0, 1, 2}), 1: frozenset({0, 1}), 2: frozenset({0, 2}), 3: frozenset({1, 2})}
+
 
 def test_remove_simplex_id(edgelist6):
     S = xgi.SimplicialComplex()

--- a/tests/classes/test_simplicialcomplex.py
+++ b/tests/classes/test_simplicialcomplex.py
@@ -50,7 +50,8 @@ def test_add_simplex():
     S2 = xgi.SimplicialComplex()
     S2.add_simplex([1, 2])
     S2.add_simplex([3, 4])
-    S2.add_simplex([5, 6], id=1)
+    with pytest.warns(UserWarning, match="uid 1 already exists, cannot add simplex"):
+        S2.add_simplex([5, 6], id=1)
     assert S2._edge == {0: frozenset({1, 2}), 1: frozenset({3, 4})}
 
 
@@ -240,15 +241,18 @@ def test_add_simplices_from(edgelist5):
 
     # check counter
     S4 = xgi.SimplicialComplex([{1, 2}, {2, 3}])
-    S4.add_simplices_from([({1, 3}, 0)])
+    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add simplex"):
+        S4.add_simplices_from([({1, 3}, 0)])
     assert S4._edge == {0: frozenset({1, 2}), 1: frozenset({2, 3})}
 
     S5 = xgi.SimplicialComplex([{1, 2}, {2, 3}])
-    S5.add_simplices_from([({0, 1}, 0, {"color": "red"})])
+    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add simplex"):
+        S5.add_simplices_from([({0, 1}, 0, {"color": "red"})])
     assert S5._edge == {0: frozenset({1, 2}), 1: frozenset({2, 3})}
 
     S6 = xgi.SimplicialComplex([{1, 2}, {2, 3}])
-    S6.add_simplices_from({0: {1, 3}})
+    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add simplex"):
+        S6.add_simplices_from({0: {1, 3}})
     assert S6._edge == {0: frozenset({1, 2}), 1: frozenset({2, 3})}
 
     S7 = xgi.SimplicialComplex()

--- a/tests/classes/test_simplicialcomplex.py
+++ b/tests/classes/test_simplicialcomplex.py
@@ -17,10 +17,15 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
 
     assert set(S_list.nodes) == set(S_df.nodes) == set(S_sc.nodes)
     assert set(S_list.edges) == set(S_df.edges) == set(S_sc.edges)
-    assert set(S_list.edges.members(0)) == set(S_df.edges.members(0)) == set(S_sc.edges.members(0))
+    assert (
+        set(S_list.edges.members(0))
+        == set(S_df.edges.members(0))
+        == set(S_sc.edges.members(0))
+    )
 
     with pytest.raises(XGIError):
         xgi.SimplicialComplex(1)
+
 
 def test_string():
     S1 = xgi.SimplicialComplex()
@@ -59,18 +64,24 @@ def test_add_edge():
     S = xgi.SimplicialComplex()
     with pytest.warns(UserWarning):
         S.add_simplex([1, 2, 3])
-        warn("add_edge is deprecated in SimplicialComplex. Use add_simplex instead", UserWarning)
+        warn(
+            "add_edge is deprecated in SimplicialComplex. Use add_simplex instead",
+            UserWarning,
+        )
     S1 = xgi.SimplicialComplex()
     S1.add_simplex([1, 2, 3])
     assert S._edge == S1._edge
 
+
 def test_add_simplices_from_iterable_of_members():
     edges = [{0, 1}, {1, 2}, {1, 2, 4}]
-    simplices1 = [frozenset({0, 1}),
-                 frozenset({1, 2}),
-                 frozenset({1, 2, 4}),
-                 frozenset({1, 4}),
-                 frozenset({2, 4})]
+    simplices1 = [
+        frozenset({0, 1}),
+        frozenset({1, 2}),
+        frozenset({1, 2, 4}),
+        frozenset({1, 4}),
+        frozenset({2, 4}),
+    ]
     S = xgi.SimplicialComplex()
     S.add_simplices_from(edges)
     assert S.edges.members() == simplices1
@@ -80,11 +91,13 @@ def test_add_simplices_from_iterable_of_members():
         xgi.SimplicialComplex(S1.edges)
 
     edges = {frozenset([0, 1]), frozenset([1, 2]), frozenset([1, 2, 4])}
-    simplices2 = [frozenset({0, 1}),
-                 frozenset({1, 2, 4}),
-                 frozenset({1, 2}),
-                 frozenset({1, 4}),
-                 frozenset({2, 4})]
+    simplices2 = [
+        frozenset({0, 1}),
+        frozenset({1, 2, 4}),
+        frozenset({1, 2}),
+        frozenset({1, 4}),
+        frozenset({2, 4}),
+    ]
     S = xgi.SimplicialComplex()
     S.add_simplices_from(edges)
     assert S.edges.members() == simplices2
@@ -95,35 +108,42 @@ def test_add_simplices_from_iterable_of_members():
     assert S.edges.members() == simplices1
 
     edges = [{"foo", "bar"}, {"bar", "baz"}, {"foo", "bar", "baz"}]
-    simplices3 = [frozenset({'bar', 'foo'}),
-                 frozenset({'bar', 'baz'}),
-                 frozenset({'bar', 'baz', 'foo'}),
-                 frozenset({'baz', 'foo'})]
+    simplices3 = [
+        frozenset({"bar", "foo"}),
+        frozenset({"bar", "baz"}),
+        frozenset({"bar", "baz", "foo"}),
+        frozenset({"baz", "foo"}),
+    ]
     S = xgi.SimplicialComplex()
     S.add_simplices_from(edges)
     assert set(S.nodes) == {"foo", "bar", "baz"}
     assert S.edges.members() == simplices3
 
     edges = [{"a", "b"}, {"b", "c"}, {"c", "d", "e"}]
-    simplices4 = [frozenset({'a', 'b'}),
-                 frozenset({'b', 'c'}),
-                 frozenset({'c', 'd', 'e'}),
-                 frozenset({'c', 'e'}),
-                 frozenset({'c', 'd'}),
-                 frozenset({'d', 'e'})]
+    simplices4 = [
+        frozenset({"a", "b"}),
+        frozenset({"b", "c"}),
+        frozenset({"c", "d", "e"}),
+        frozenset({"c", "e"}),
+        frozenset({"c", "d"}),
+        frozenset({"d", "e"}),
+    ]
 
     S = xgi.SimplicialComplex()
     S.add_simplices_from(edges)
     assert set(S.nodes) == {"a", "b", "c", "d", "e"}
     assert set(S.edges.members()) == set(simplices4)
 
+
 def test_add_simplices_from_format2():
     edges = [({0, 1}, 0), ({1, 2}, 1), ({1, 2, 4}, 2)]
-    simplices1 = [frozenset({0, 1}),
-                 frozenset({1, 2}),
-                 frozenset({1, 2, 4}),
-                 frozenset({1, 4}),
-                 frozenset({2, 4})]
+    simplices1 = [
+        frozenset({0, 1}),
+        frozenset({1, 2}),
+        frozenset({1, 2, 4}),
+        frozenset({1, 4}),
+        frozenset({2, 4}),
+    ]
     H = xgi.SimplicialComplex()
     H.add_simplices_from(edges)
     assert list(H.edges) == list(range(6))
@@ -146,7 +166,9 @@ def test_add_simplices_from_format2():
     assert H.edges.members(101) == {1, 9, 2}
 
     H1 = xgi.SimplicialComplex([{1, 2}, {2, 3, 4}])
-    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add edge {1, 3}."):
+    with pytest.warns(
+        UserWarning, match="uid 0 already exists, cannot add edge {1, 3}."
+    ):
         H1.add_edges_from([({1, 3}, 0)])
     assert H1._edge == {0: {1, 2}, 1: {2, 3, 4}}
 
@@ -157,11 +179,13 @@ def test_add_simplices_from_format3():
         ({1, 2}, {"age": 30}),
         ({1, 2, 4}, {"color": "blue", "age": 40}),
     ]
-    simplices1 = [frozenset({0, 1}),
-                 frozenset({1, 2}),
-                 frozenset({1, 2, 4}),
-                 frozenset({1, 4}),
-                 frozenset({2, 4})]
+    simplices1 = [
+        frozenset({0, 1}),
+        frozenset({1, 2}),
+        frozenset({1, 2, 4}),
+        frozenset({1, 4}),
+        frozenset({2, 4}),
+    ]
     H = xgi.SimplicialComplex()
     H.add_simplices_from(edges)
     assert list(H.edges) == list(range(5))
@@ -175,21 +199,24 @@ def test_add_simplices_from_format3():
     H.add_simplex([1, 9, 2])
     assert H.edges.members(5) == {1, 9, 2}
 
+
 def test_add_simplices_from_format4():
     edges = [
         ({0, 1}, "one", {"color": "red"}),
         ({1, 2}, "two", {"age": 30}),
         ({1, 2, 4}, "three", {"color": "blue", "age": 40}),
     ]
-    simplices1 = [frozenset({0, 1}),
-                 frozenset({1, 2}),
-                 frozenset({1, 2, 4}),
-                 frozenset({1, 4}),
-                 frozenset({2, 4})]
+    simplices1 = [
+        frozenset({0, 1}),
+        frozenset({1, 2}),
+        frozenset({1, 2, 4}),
+        frozenset({1, 4}),
+        frozenset({2, 4}),
+    ]
 
     H = xgi.SimplicialComplex()
     H.add_simplices_from(edges)
-    assert list(H.edges) == ['one', 'two', 'three', 0, 1]
+    assert list(H.edges) == ["one", "two", "three", 0, 1]
     assert H.edges.members() == simplices1
     assert H.edges["one"] == edges[0][2]
     assert H.edges["two"] == edges[1][2]
@@ -201,28 +228,34 @@ def test_add_simplices_from_format4():
     assert H.edges.members(2) == {1, 9, 2}
 
     H1 = xgi.SimplicialComplex([{1, 2}, {2, 3, 4}])
-    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add simplex {0, 1}."):
+    with pytest.warns(
+        UserWarning, match="uid 0 already exists, cannot add simplex {0, 1}."
+    ):
         H1.add_simplices_from([({0, 1}, 0, {"color": "red"})])
     assert next(H1._edge_uid) == 5
 
 
 def test_add_edges_from_dict():
     edges = {"one": [0, 1], "two": [1, 2], 2: [1, 2, 4]}
-    simplices1 = [frozenset({0, 1}),
-                 frozenset({1, 2}),
-                 frozenset({1, 2, 4}),
-                 frozenset({1, 4}),
-                 frozenset({2, 4})]
+    simplices1 = [
+        frozenset({0, 1}),
+        frozenset({1, 2}),
+        frozenset({1, 2, 4}),
+        frozenset({1, 4}),
+        frozenset({2, 4}),
+    ]
     H = xgi.SimplicialComplex()
     H.add_simplices_from(edges)
-    assert list(H.edges) == ['one', 'two', 2, 3, 4]
+    assert list(H.edges) == ["one", "two", 2, 3, 4]
     assert H.edges.members() == simplices1
     # check counter
     H.add_edge([1, 9, 2])
     assert H.edges.members(5) == {1, 9, 2}
 
     H1 = xgi.SimplicialComplex([{1, 2}, {2, 3, 4}])
-    with pytest.warns(UserWarning, match="uid 0 already exists, cannot add simplex {1, 3}"):
+    with pytest.warns(
+        UserWarning, match="uid 0 already exists, cannot add simplex {1, 3}"
+    ):
         H1.add_simplices_from({0: {1, 3}})
     assert next(H1._edge_uid) == 5
 
@@ -278,7 +311,12 @@ def test_add_simplices_from(edgelist5):
 
     S7 = xgi.SimplicialComplex()
     S7.add_simplices_from([({0, 1, 2}, 0, {})])
-    assert S7._edge == {0: frozenset({0, 1, 2}), 1: frozenset({0, 1}), 2: frozenset({0, 2}), 3: frozenset({1, 2})}
+    assert S7._edge == {
+        0: frozenset({0, 1, 2}),
+        1: frozenset({0, 1}),
+        2: frozenset({0, 2}),
+        3: frozenset({1, 2}),
+    }
 
 
 def test_add_simplices_from_wrong_format():
@@ -368,12 +406,14 @@ def test_duplicate_edges(edgelist1):
     H = xgi.SimplicialComplex([[1, 2, 3, 3], [3, 1, 2, 3]])  # repeated nodes
     assert set(H.edges.duplicates()) == set()
 
+
 def test_duplicate_nodes(edgelist1):
     H = xgi.SimplicialComplex(edgelist1)
     assert set(H.nodes.duplicates()) == set()
 
     H.add_simplices_from([[1, 4], [2, 6, 7], [6, 8]])
     assert set(H.nodes.duplicates()) == set()
+
 
 def test_remove_simplex_id(edgelist6):
     S = xgi.SimplicialComplex()

--- a/tests/classes/test_simplicialcomplex.py
+++ b/tests/classes/test_simplicialcomplex.py
@@ -1,4 +1,5 @@
 import pytest
+from warnings import warn
 
 import xgi
 from xgi.exception import XGIError
@@ -55,8 +56,9 @@ def test_add_simplex():
 
 def test_add_edge():
     S = xgi.SimplicialComplex()
-    with pytest.raises(XGIError):
-        S.add_edge([1, 2, 3])
+    with pytest.warns(UserWarning):
+        S.add_simplex([1, 2, 3])
+        warn("add_edge is deprecated in SimplicialComplex. Use add_simplex instead", UserWarning)
 
 
 def test_add_simplices_from(edgelist5):

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -652,7 +652,7 @@ class Hypergraph:
         if isinstance(ebunch_to_add, dict):
             for id, members in ebunch_to_add.items():
                 if id in self._edge.keys():  # check that uid is not present yet
-                    warn(f"uid {id} already exists, cannot add edge ")
+                    warn(f"uid {id} already exists, cannot add edge {members}.")
                     continue
                 try:
                     self._edge[id] = set(members)
@@ -712,7 +712,7 @@ class Hypergraph:
                 members, id, eattr = e[0], e[1], e[2]
 
             if id in self._edge.keys():  # check that uid is not present yet
-                warn(f"uid {id} already exists, cannot add edge.")
+                warn(f"uid {id} already exists, cannot add edge {members}.")
             else:
 
                 try:

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -134,6 +134,10 @@ class SimplicialComplex(Hypergraph):
         warn("remove_edges_from is deprecated in SimplicialComplex. Use remove_simplex_ids_from instead")
         return self.remove_simplex_ids_from(ebunch)
 
+    def add_node_to_edge(self, edge, node):
+        """add_node_to_edge is not implemented in SimplicialComplex."""
+        raise XGIError("add_node_to_edge is not implemented in SimplicialComplex.")
+
     def add_simplex(self, members, id=None, **attr):
         """Add a simplex to the simplicial complex, and all its subfaces that do
         not exist yet.
@@ -442,10 +446,18 @@ class SimplicialComplex(Hypergraph):
             elif format4:
                 members, id, eattr = e[0], e[1], e[2]
 
+            # check if members is iterable before checking it exists
+            # to raise meaningful error if not iterable
+            try: 
+                _ = iter(members)
+            except TypeError as e:
+                raise XGIError("Invalid ebunch format") from e
+
             # check that it does not exist yet (based on members, not ID)
             if not members or self.has_simplex(members):
                 try:
                     e = next(new_edges)
+
                 except StopIteration:
                     break
 
@@ -627,6 +639,7 @@ class SimplicialComplex(Hypergraph):
                 self._node[node].remove(id)
             del self._edge[id]
             del self._edge_attr[id]
+            
 
     def has_simplex(self, simplex):
         """Whether a simplex appears in the simplicial complex.

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -392,11 +392,11 @@ class SimplicialComplex(Hypergraph):
                     self._node[n].add(id)
                 self._edge_attr[id] = self._hyperedge_attr_dict_factory()
 
+                update_uid_counter(self, id)
+
                 # add subfaces
                 faces = self._subfaces(members)
                 self.add_simplices_from(faces)
-
-                update_uid_counter(self, id)
 
             return
 
@@ -487,6 +487,9 @@ class SimplicialComplex(Hypergraph):
                 self._edge_attr[id].update(attr)
                 self._edge_attr[id].update(eattr)
 
+                if format2 or format4:
+                    update_uid_counter(self, id)
+
                 # add subfaces
                 faces = self._subfaces(members)
                 self.add_simplices_from(faces)
@@ -494,9 +497,6 @@ class SimplicialComplex(Hypergraph):
             try:
                 e = next(new_edges)
             except StopIteration:
-
-                if format2 or format4:
-                    update_uid_counter(self, id)
 
                 break
 

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -392,11 +392,11 @@ class SimplicialComplex(Hypergraph):
                     self._node[n].add(id)
                 self._edge_attr[id] = self._hyperedge_attr_dict_factory()
 
-                update_uid_counter(self, id)
-
                 # add subfaces
                 faces = self._subfaces(members)
                 self.add_simplices_from(faces)
+
+                update_uid_counter(self, id)
 
             return
 
@@ -487,9 +487,6 @@ class SimplicialComplex(Hypergraph):
                 self._edge_attr[id].update(attr)
                 self._edge_attr[id].update(eattr)
 
-                if format2 or format4:
-                    update_uid_counter(self, id)
-
                 # add subfaces
                 faces = self._subfaces(members)
                 self.add_simplices_from(faces)
@@ -497,6 +494,9 @@ class SimplicialComplex(Hypergraph):
             try:
                 e = next(new_edges)
             except StopIteration:
+
+                if format2 or format4:
+                    update_uid_counter(self, id)
 
                 break
 

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -109,33 +109,30 @@ class SimplicialComplex(Hypergraph):
         except XGIError:
             return f"Unnamed {type(self).__name__} with {self.num_nodes} nodes and {self.num_edges} simplices"
 
-    def add_edge(self, edge, **attr):
-        """Cannot `add_edge` to SimplicialComplex, use `add_simplex` instead"""
-        raise XGIError("Cannot add_edge to SimplicialComplex, use add_simplex instead")
+    def add_edge(self, edge, id=None, **attr):
+        """add_edge is deprecated in SimplicialComplex. Use add_simplex instead"""
+        warn("add_edge is deprecated in SimplicialComplex. Use add_simplex instead")
+        return self.add_simplex(edge, id=None, **attr)
 
-    def add_edges_from(self, edges, **attr):
-        """Cannot `add_edges_from` to SimplicialComplex, use `add_simplices_from` instead"""
-        raise XGIError(
-            "Cannot add_edges_from to SimplicialComplex, use add_simplices_from instead"
-        )
+    def add_edges_from(self, ebunch_to_add, max_order=None, **attr):
+        """add_edges_from is deprecated in SimplicialComplex. Use add_simplices_from instead"""
+        warn("add_edges_from is deprecated in SimplicialComplex. Use add_simplices_from instead")
+        return self.add_simplices_from(ebunch_to_add, max_order=None, **attr)
 
-    def add_weighted_edges_from(self, ebunch_to_add, weight="weight", **attr):
-        """Cannot `add_weighted_edges_from` to SimplicialComplex, use add_weighted_simplices_from instead"""
-        raise XGIError(
-            "Cannot add_weighted_edges_from to SimplicialComplex, use add_weighted_simplices_from instead"
-        )
+    def add_weighted_edges_from(self, ebunch_to_add, max_order=None, weight="weight", **attr):
+        """add_weighted_edges_from is deprecated in SimplicialComplex. Use add_weighted_simplices_from instead"""
+        warn("add_weighted_edges_from is deprecated in SimplicialComplex. Use add_weighted_simplices_from instead")
+        return self.add_weighted_simplices_from(ebunch_to_add, max_order=None, weight="weight", **attr)
 
     def remove_edge(self, id):
-        """Cannot `remove_edge` to SimplicialComplex, use `remove_simplex` instead"""
-        raise XGIError(
-            "Cannot remove_edge to SimplicialComplex, use remove_simplex instead"
-        )
+        """remove_edge is deprecated in SimplicialComplex. Use remove_simplex_id instead"""
+        warn("remove_edge is deprecated in SimplicialComplex. Use remove_simplex_id instead")
+        return self.remove_simplex_id(id, **attr)
 
     def remove_edges_from(self, ebunch):
-        """Cannot `remove_edges_from` to SimplicialComplex, use `remove_simplices_from` instead"""
-        raise XGIError(
-            "Cannot remove_edges_from to SimplicialComplex, use remove_simplices_from instead"
-        )
+        """remove_edges_from is deprecated in SimplicialComplex. Use remove_simplex_ids_from instead"""
+        warn("remove_edges_from is deprecated in SimplicialComplex. Use remove_simplex_ids_from instead")
+        return self.remove_simplex_ids_from(ebunch)
 
     def add_simplex(self, members, id=None, **attr):
         """Add a simplex to the simplicial complex, and all its subfaces that do

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -116,22 +116,34 @@ class SimplicialComplex(Hypergraph):
 
     def add_edges_from(self, ebunch_to_add, max_order=None, **attr):
         """add_edges_from is deprecated in SimplicialComplex. Use add_simplices_from instead"""
-        warn("add_edges_from is deprecated in SimplicialComplex. Use add_simplices_from instead")
+        warn(
+            "add_edges_from is deprecated in SimplicialComplex. Use add_simplices_from instead"
+        )
         return self.add_simplices_from(ebunch_to_add, max_order=None, **attr)
 
-    def add_weighted_edges_from(self, ebunch_to_add, max_order=None, weight="weight", **attr):
+    def add_weighted_edges_from(
+        self, ebunch_to_add, max_order=None, weight="weight", **attr
+    ):
         """add_weighted_edges_from is deprecated in SimplicialComplex. Use add_weighted_simplices_from instead"""
-        warn("add_weighted_edges_from is deprecated in SimplicialComplex. Use add_weighted_simplices_from instead")
-        return self.add_weighted_simplices_from(ebunch_to_add, max_order=None, weight="weight", **attr)
+        warn(
+            "add_weighted_edges_from is deprecated in SimplicialComplex. Use add_weighted_simplices_from instead"
+        )
+        return self.add_weighted_simplices_from(
+            ebunch_to_add, max_order=None, weight="weight", **attr
+        )
 
     def remove_edge(self, id):
         """remove_edge is deprecated in SimplicialComplex. Use remove_simplex_id instead"""
-        warn("remove_edge is deprecated in SimplicialComplex. Use remove_simplex_id instead")
+        warn(
+            "remove_edge is deprecated in SimplicialComplex. Use remove_simplex_id instead"
+        )
         return self.remove_simplex_id(id, **attr)
 
     def remove_edges_from(self, ebunch):
         """remove_edges_from is deprecated in SimplicialComplex. Use remove_simplex_ids_from instead"""
-        warn("remove_edges_from is deprecated in SimplicialComplex. Use remove_simplex_ids_from instead")
+        warn(
+            "remove_edges_from is deprecated in SimplicialComplex. Use remove_simplex_ids_from instead"
+        )
         return self.remove_simplex_ids_from(ebunch)
 
     def add_node_to_edge(self, edge, node):
@@ -448,7 +460,7 @@ class SimplicialComplex(Hypergraph):
 
             # check if members is iterable before checking it exists
             # to raise meaningful error if not iterable
-            try: 
+            try:
                 _ = iter(members)
             except TypeError as e:
                 raise XGIError("Invalid ebunch format") from e
@@ -639,7 +651,6 @@ class SimplicialComplex(Hypergraph):
                 self._node[node].remove(id)
             del self._edge[id]
             del self._edge_attr[id]
-            
 
     def has_simplex(self, simplex):
         """Whether a simplex appears in the simplicial complex.

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -392,11 +392,11 @@ class SimplicialComplex(Hypergraph):
                     self._node[n].add(id)
                 self._edge_attr[id] = self._hyperedge_attr_dict_factory()
 
+                update_uid_counter(self, id)
+
                 # add subfaces
                 faces = self._subfaces(members)
                 self.add_simplices_from(faces)
-
-                update_uid_counter(self, id)
 
             return
 
@@ -455,7 +455,6 @@ class SimplicialComplex(Hypergraph):
             # we're skipping ID numbers when edges already exist
             if format1 or format3:
                 id = next(self._edge_uid)
-
             if max_order != None:
                 if len(members) > max_order + 1:
                     combos = combinations(members, max_order + 1)
@@ -487,6 +486,9 @@ class SimplicialComplex(Hypergraph):
                 self._edge_attr[id].update(attr)
                 self._edge_attr[id].update(eattr)
 
+                if format2 or format4:
+                    update_uid_counter(self, id)
+
                 # add subfaces
                 faces = self._subfaces(members)
                 self.add_simplices_from(faces)
@@ -494,9 +496,6 @@ class SimplicialComplex(Hypergraph):
             try:
                 e = next(new_edges)
             except StopIteration:
-
-                if format2 or format4:
-                    update_uid_counter(self, id)
 
                 break
 

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -469,7 +469,7 @@ class SimplicialComplex(Hypergraph):
                     continue
 
             if id in self._edge.keys():  # check that uid is not present yet
-                warn(f"uid {id} already exists, cannot add edge.")
+                warn(f"uid {id} already exists, cannot add simplex {members}.")
             else:
 
                 try:

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -144,7 +144,9 @@ def convert_to_simplicial_complex(data, create_using=None):
         H = empty_simplicial_complex(create_using)
         H.add_nodes_from((n, attr) for n, attr in data.nodes.items())
         ee = data.edges
-        H.add_simplices_from((ee.members(e), e, deepcopy(attr)) for e, attr in ee.items())
+        H.add_simplices_from(
+            (ee.members(e), e, deepcopy(attr)) for e, attr in ee.items()
+        )
         H._hypergraph = deepcopy(data._hypergraph)
 
     elif isinstance(data, list):

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -144,7 +144,7 @@ def convert_to_simplicial_complex(data, create_using=None):
         H = empty_simplicial_complex(create_using)
         H.add_nodes_from((n, attr) for n, attr in data.nodes.items())
         ee = data.edges
-        H.add_edges_from((ee.members(e), e, deepcopy(attr)) for e, attr in ee.items())
+        H.add_simplices_from((ee.members(e), e, deepcopy(attr)) for e, attr in ee.items())
         H._hypergraph = deepcopy(data._hypergraph)
 
     elif isinstance(data, list):

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -114,4 +114,3 @@ def update_uid_counter(H, new_id):
     else:
         start = uid
     H._edge_uid = count(start=start)
-

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -105,7 +105,7 @@ def update_uid_counter(H, new_id):
         not isinstance(new_id, str)
         and not isinstance(new_id, tuple)
         and float(new_id).is_integer()
-        and uid < new_id
+        and uid < new_id + 1
     ):
         # tuple comes from merging edges and doesn't have as as_integer() method.
         start = int(new_id) + 1


### PR DESCRIPTION
- added lots of tests
- changed the behaviour of inherited Hypergraph methods such as `add_edge`: instead of raising an error and not adding the simplex, we now add the simplex and raise a warning. 
- a consequence of the previous point is that some HG methods that did not work for SCs now do (and raise a warning): e.g. `copy()`
- added tests to check the new warnings and other old warnings
- fixed an off-by-one in update_uid_counter #243 

The cleanup of the SimplicialComplex is not finished yet but I feel like this PR is getting big already. 
There is one test that does not pass, due to #244. I feel like fixing it would be a lot of code change and would be better in another PR. (The test is new and the fact that it does not pass just highlights a pre-existing bug)