### PR TITLE
Update simplicial kuramoto module

### DIFF
--- a/tests/dynamics/test_synchronization.py
+++ b/tests/dynamics/test_synchronization.py
@@ -40,7 +40,7 @@ def test_simulate_simplicial_kuramoto():
     n2 = len(S.edges.filterby("order", 2))
 
     theta, theta_minus, theta_plus = xgi.simulate_simplicial_kuramoto(
-        S, None, 1, np.ones((n1, 1)), 1, np.ones((n1, 1)), 1, 30, False
+        S, None, 1, np.ones(n1), 1, np.ones(n1), 1, 30, False
     )
     r = xgi.compute_simplicial_order_parameter(theta_minus, theta_plus)
 

--- a/xgi/linalg/matrix.py
+++ b/xgi/linalg/matrix.py
@@ -426,6 +426,7 @@ def boundary_matrix(S, order=1, orientations=None, index=False):
 
     if orientations is None:
         orientations = {idd: 0 for idd in S.edges.filterby("order", 1, mode="geq")}
+        print(orientations)
 
     B = np.zeros((nd, nu))
     if not (nu == 0 or nd == 0):


### PR DESCRIPTION
- remove non-necessary extra dimension for theta0 and omega
- allow use of scipy solve_ivp integrator for better precision
- use random default theta0 and omega, so it does not crash if user does not specify anything (which is allowed from function signature)