### PR TITLE
Remove data refs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,6 @@ include CITATION.cff
 include CODE_OF_CONDUCT.md
 include pytest.ini
 
-recursive-include data *.txt
 recursive-include tutorials *.ipynb
 recursive-include logo *.pdf *.png *.svg
 recursive-include requirements *.txt *.md

--- a/benchmarks/benchmarks/bench_core_hypergraph.py
+++ b/benchmarks/benchmarks/bench_core_hypergraph.py
@@ -7,20 +7,19 @@ from .common import Benchmark
 
 class CoreHypergraph(Benchmark):
     def setup(self):
-        fname = "../../data/disGene.txt"
-        self.hypergraph = xgi.read_bipartite_edgelist(fname, delimiter=" ")
-        self.disgene_edgelist = xgi.to_hyperedge_list(self.hypergraph)
-        self.disgene_edgedict = xgi.to_hyperedge_dict(self.hypergraph)
-        self.disgene_df = pd.read_csv(fname, delimiter=" ", header=None)
+        self.hypergraph = xgi.load_xgi_data("email-enron")
+        self.enron_edgelist = xgi.to_hyperedge_list(self.hypergraph)
+        self.enron_edgedict = xgi.to_hyperedge_dict(self.hypergraph)
+        self.enron_df = xgi.to_bipartite_pandas_dataframe(self.hypergraph)
 
     def time_edgelist_construction(self):
-        xgi.Hypergraph(self.disgene_edgelist)
+        xgi.Hypergraph(self.enron_edgelist)
 
     def time_edgedict_construction(self):
-        xgi.Hypergraph(self.disgene_edgedict)
+        xgi.Hypergraph(self.enron_edgedict)
 
     def time_df_construction(self):
-        xgi.Hypergraph(self.disgene_df)
+        xgi.Hypergraph(self.enron_df)
 
     def time_node_memberships(self):
         [self.hypergraph.nodes.memberships(n) for n in self.hypergraph.nodes]

--- a/benchmarks/hypernetx.ipynb
+++ b/benchmarks/hypernetx.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,29 +23,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fname = \"../data/disGene.txt\"\n",
-    "df = pd.read_csv(fname, delimiter=\" \", header=None)"
+    "data = xgi.load_xgi_data(\"email-enron\")\n",
+    "data.cleanup()\n",
+    "edgelist = xgi.to_hyperedge_list(data)\n",
+    "df = xgi.to_bipartite_pandas_dataframe(data)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI edgelist construction time: 0.011233806610107422 sec\n",
+      "The hypergraph has 1459 nodes and 143 edges.\n",
+      "HyperNetX edgelist construction time: 0.023783206939697266 sec\n",
+      "The hypergraph has 143 nodes and 1459 edges.\n"
+     ]
+    }
+   ],
    "source": [
     "start = time.time()\n",
-    "H1 = xgi.Hypergraph(df)\n",
+    "H1 = xgi.Hypergraph(edgelist)\n",
     "H1 = H1.dual()\n",
-    "print(f\"XGI construction time: {time.time() - start} sec\")\n",
+    "print(f\"XGI edgelist construction time: {time.time() - start} sec\")\n",
     "print(f\"The hypergraph has {H1.num_nodes} nodes and {H1.num_edges} edges.\")\n",
     "\n",
     "start = time.time()\n",
-    "H2 = hnx.Hypergraph(df, static=True)\n",
-    "print(f\"HyperNetX construction time: {time.time() - start} sec\")\n",
+    "H2 = hnx.Hypergraph(edgelist, static=True)\n",
+    "print(f\"HyperNetX edgelist construction time: {time.time() - start} sec\")\n",
     "print(\n",
     "    f\"The hypergraph has {H2.number_of_nodes()} nodes and {H2.number_of_edges()} edges.\"\n",
     ")"
@@ -53,9 +66,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI edgelist construction time: 0.010957956314086914 sec\n",
+      "The hypergraph has 1459 nodes and 143 edges.\n",
+      "HyperNetX edgelist construction time: 0.2202610969543457 sec\n",
+      "The hypergraph has 1459 nodes and 143 edges.\n"
+     ]
+    }
+   ],
+   "source": [
+    "start = time.time()\n",
+    "H1 = xgi.Hypergraph(df)\n",
+    "H1 = H1.dual()\n",
+    "print(f\"XGI edgelist construction time: {time.time() - start} sec\")\n",
+    "print(f\"The hypergraph has {H1.num_nodes} nodes and {H1.num_edges} edges.\")\n",
+    "\n",
+    "start = time.time()\n",
+    "H2 = hnx.Hypergraph(df, static=True)\n",
+    "print(f\"HyperNetX edgelist construction time: {time.time() - start} sec\")\n",
+    "print(\n",
+    "    f\"The hypergraph has {H2.number_of_nodes()} nodes and {H2.number_of_edges()} edges.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI dual hypergraph construction time:\n",
+      "6.28 ms ± 133 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n",
+      "HyperNetX dual hypergraph construction time:\n",
+      "38.4 ms ± 393 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"XGI dual hypergraph construction time:\")\n",
     "%timeit H1.dual()\n",
@@ -66,9 +121,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI incidence matrix construction time:\n",
+      "60.4 ms ± 1.69 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "HyperNetX incidence matrix construction time:\n",
+      "158 ns ± 0.0754 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"XGI incidence matrix construction time:\")\n",
     "%timeit I1 = xgi.incidence_matrix(H1)\n",
@@ -78,9 +144,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI adjacency matrix construction time:\n",
+      "110 ms ± 1.06 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "HyperNetX adjacency matrix construction time:\n",
+      "45 ms ± 88.1 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"XGI adjacency matrix construction time:\")\n",
     "%timeit xgi.adjacency_matrix(H1)\n",
@@ -91,9 +168,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI adjacency dictionary retrieval time:\n",
+      "57.8 ms ± 330 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "XGI adjacency dictionary retrieval time:\n",
+      "198 ms ± 1.77 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"XGI adjacency dictionary retrieval time:\")\n",
     "%timeit xgi.to_hyperedge_dict(H1)\n",
@@ -104,9 +192,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI node memberships retrieval time:\n",
+      "0.003931760787963867 sec\n",
+      "HyperNetX node memberships retrieval time:\n",
+      "0.02753615379333496 sec\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"XGI node memberships retrieval time:\")\n",
     "start = time.time()\n",
@@ -123,9 +222,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI hyperedge retrieval time:\n",
+      "0.007923126220703125 sec\n",
+      "HyperNetX hyperedge retrieval time:\n",
+      "3.9082751274108887 sec\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"XGI hyperedge retrieval time:\")\n",
     "start = time.time()\n",
@@ -142,9 +252,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI time to determine connectedness:\n",
+      "178 ms ± 4.03 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "HyperNetX time to determine connectedness:\n",
+      "272 ms ± 234 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"XGI time to determine connectedness:\")\n",
     "%timeit xgi.is_connected(H1)\n",
@@ -155,9 +276,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI time to determine connected components:\n",
+      "181 ms ± 4.5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "HyperNetX time to determine connected components:\n",
+      "284 ms ± 2.03 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"XGI time to determine connected components:\")\n",
     "%timeit [len(cc) for cc in xgi.connected_components(H1)]\n",
@@ -168,9 +300,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGI time to construct Chung-Lu hypergraph:\n",
+      "135 ms ± 2.54 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "HyperNetX time to construct Chung-Lu hypergraph:\n",
+      "5.98 s ± 21.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
    "source": [
     "k1 = H1.nodes.degree.asdict()\n",
     "k2 = H1.edges.size.asdict()\n",
@@ -184,11 +327,8 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "fdeb83b6e5b2333358b6ba79181fac315f1a722b4574d7079c134c9ae27f7c53"
-  },
   "kernelspec": {
-   "display_name": "Python 3.9.7",
+   "display_name": "hyper",
    "language": "python",
    "name": "python3"
   },
@@ -202,7 +342,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d499419bfd3ffc3e3fdefe0b9d84e10a93ca5c11fd9f2ad00edb8d726bc70f5f"
+   }
   }
  },
  "nbformat": 4,

--- a/benchmarks/hypernetx.ipynb
+++ b/benchmarks/hypernetx.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,20 +35,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI edgelist construction time: 0.011233806610107422 sec\n",
-      "The hypergraph has 1459 nodes and 143 edges.\n",
-      "HyperNetX edgelist construction time: 0.023783206939697266 sec\n",
-      "The hypergraph has 143 nodes and 1459 edges.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "start = time.time()\n",
     "H1 = xgi.Hypergraph(edgelist)\n",
@@ -66,20 +55,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI edgelist construction time: 0.010957956314086914 sec\n",
-      "The hypergraph has 1459 nodes and 143 edges.\n",
-      "HyperNetX edgelist construction time: 0.2202610969543457 sec\n",
-      "The hypergraph has 1459 nodes and 143 edges.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "start = time.time()\n",
     "H1 = xgi.Hypergraph(df)\n",
@@ -97,20 +75,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI dual hypergraph construction time:\n",
-      "6.28 ms ± 133 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n",
-      "HyperNetX dual hypergraph construction time:\n",
-      "38.4 ms ± 393 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"XGI dual hypergraph construction time:\")\n",
     "%timeit H1.dual()\n",
@@ -121,20 +88,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI incidence matrix construction time:\n",
-      "60.4 ms ± 1.69 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "HyperNetX incidence matrix construction time:\n",
-      "158 ns ± 0.0754 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"XGI incidence matrix construction time:\")\n",
     "%timeit I1 = xgi.incidence_matrix(H1)\n",
@@ -144,20 +100,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI adjacency matrix construction time:\n",
-      "110 ms ± 1.06 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "HyperNetX adjacency matrix construction time:\n",
-      "45 ms ± 88.1 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"XGI adjacency matrix construction time:\")\n",
     "%timeit xgi.adjacency_matrix(H1)\n",
@@ -168,20 +113,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI adjacency dictionary retrieval time:\n",
-      "57.8 ms ± 330 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "XGI adjacency dictionary retrieval time:\n",
-      "198 ms ± 1.77 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"XGI adjacency dictionary retrieval time:\")\n",
     "%timeit xgi.to_hyperedge_dict(H1)\n",
@@ -192,20 +126,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI node memberships retrieval time:\n",
-      "0.003931760787963867 sec\n",
-      "HyperNetX node memberships retrieval time:\n",
-      "0.02753615379333496 sec\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"XGI node memberships retrieval time:\")\n",
     "start = time.time()\n",
@@ -222,20 +145,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI hyperedge retrieval time:\n",
-      "0.007923126220703125 sec\n",
-      "HyperNetX hyperedge retrieval time:\n",
-      "3.9082751274108887 sec\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"XGI hyperedge retrieval time:\")\n",
     "start = time.time()\n",
@@ -252,20 +164,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI time to determine connectedness:\n",
-      "178 ms ± 4.03 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "HyperNetX time to determine connectedness:\n",
-      "272 ms ± 234 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"XGI time to determine connectedness:\")\n",
     "%timeit xgi.is_connected(H1)\n",
@@ -276,20 +177,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI time to determine connected components:\n",
-      "181 ms ± 4.5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "HyperNetX time to determine connected components:\n",
-      "284 ms ± 2.03 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"XGI time to determine connected components:\")\n",
     "%timeit [len(cc) for cc in xgi.connected_components(H1)]\n",
@@ -300,20 +190,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XGI time to construct Chung-Lu hypergraph:\n",
-      "135 ms ± 2.54 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "HyperNetX time to construct Chung-Lu hypergraph:\n",
-      "5.98 s ± 21.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "k1 = H1.nodes.degree.asdict()\n",
     "k2 = H1.edges.size.asdict()\n",
@@ -342,7 +221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.6 | packaged by conda-forge | (main, Aug 22 2022, 20:38:29) [Clang 13.0.1 ]"
   },
   "vscode": {
    "interpreter": {

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -84,13 +84,23 @@ def test_to_bipartite_pandas_dataframe():
         [8, 3],
     ]
 
-    true_df = pd.DataFrame(true_bi_el1, columns=["Node ID", "Edge ID"])
-    H1 = xgi.Hypergraph(true_df)
+    true_bi_el2 = [[1, 0], [2, 0], [3, 0], [3, 1], [4, 1], [4, 2], [5, 2], [6, 2]]
 
-    df = xgi.to_bipartite_pandas_dataframe(H1)
+    true_df1 = pd.DataFrame(true_bi_el1, columns=["Node ID", "Edge ID"])
+    H1 = xgi.Hypergraph(true_df1)
 
-    assert df.shape == true_df.shape
-    assert df.equals(true_df)
+    df1 = xgi.to_bipartite_pandas_dataframe(H1)
+
+    assert df1.shape == true_df1.shape
+    assert df1.equals(true_df1)
+
+    true_df2 = pd.DataFrame(true_bi_el2, columns=["Node ID", "Edge ID"])
+    H2 = xgi.Hypergraph(true_df2)
+
+    df2 = xgi.to_bipartite_pandas_dataframe(H2)
+
+    assert df2.shape == true_df2.shape
+    assert df2.equals(true_df2)
 
 
 def test_to_bipartite_graph(edgelist1, edgelist3, edgelist4):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 import xgi
@@ -68,6 +69,28 @@ def test_from_bipartite_pandas_dataframe(dataframe5):
         xgi.from_bipartite_pandas_dataframe(
             dataframe5, node_column=0, edge_column="test2"
         )
+
+
+def test_to_bipartite_pandas_dataframe():
+    true_bi_el1 = [
+        [1, 0],
+        [2, 0],
+        [3, 0],
+        [4, 1],
+        [5, 2],
+        [6, 2],
+        [6, 3],
+        [7, 3],
+        [8, 3],
+    ]
+
+    true_df = pd.DataFrame(true_bi_el1, columns=["Node ID", "Edge ID"])
+    H1 = xgi.Hypergraph(true_df)
+
+    df = xgi.to_bipartite_pandas_dataframe(H1)
+
+    assert df.shape == true_df.shape
+    assert df.equals(true_df)
 
 
 def test_to_bipartite_graph(edgelist1, edgelist3, edgelist4):

--- a/tutorials/Tutorial 1 - Basic Hypergraph Functionality.ipynb
+++ b/tutorials/Tutorial 1 - Basic Hypergraph Functionality.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,8 +65,7 @@
     "}\n",
     "\n",
     "# pandas dataframe\n",
-    "fname = \"../data/disGene.txt\"\n",
-    "df = pd.read_csv(fname, delimiter=\" \", header=None)\n",
+    "df = xgi.to_bipartite_pandas_dataframe(xgi.load_xgi_data(\"email-enron\"))\n",
     "\n",
     "# incidence matrix\n",
     "incidence_matrix = np.random.randint(0, high=2, size=(n, m), dtype=int)"
@@ -346,7 +345,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.6 ('venv': venv)",
+   "display_name": "hyper",
    "language": "python",
    "name": "python3"
   },
@@ -377,7 +376,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "78db47bee367e3fae825d59af43d695909ce208402094df58551906768c6e91c"
+    "hash": "d499419bfd3ffc3e3fdefe0b9d84e10a93ca5c11fd9f2ad00edb8d726bc70f5f"
    }
   }
  },

--- a/tutorials/Tutorial 3 - Basic simplicial complex usage.ipynb
+++ b/tutorials/Tutorial 3 - Basic simplicial complex usage.ipynb
@@ -459,8 +459,7 @@
    },
    "outputs": [],
    "source": [
-    "fname = \"../data/disGene.txt\"\n",
-    "df = pd.read_csv(fname, delimiter=\" \", header=None)"
+    "df = xgi.to_bipartite_pandas_dataframe(xgi.load_xgi_data(\"email-enron\"))"
    ]
   },
   {
@@ -670,7 +669,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "hyper",
    "language": "python",
    "name": "python3"
   },
@@ -684,7 +683,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.6 | packaged by conda-forge | (main, Aug 22 2022, 20:38:29) [Clang 13.0.1 ]"
   },
   "toc": {
    "base_numbering": 1,
@@ -698,6 +697,11 @@
    "toc_position": {},
    "toc_section_display": true,
    "toc_window_display": false
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d499419bfd3ffc3e3fdefe0b9d84e10a93ca5c11fd9f2ad00edb8d726bc70f5f"
+   }
   }
  },
  "nbformat": 4,

--- a/tutorials/quickstart.ipynb
+++ b/tutorials/quickstart.ipynb
@@ -191,10 +191,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Likewise, one can load from a file. For example, in the `data` folder, there is a disease-gene hypergraph in bipartite edgelist format, where nodes are diseases and edges are genes. We can read in this dataset:"
+    "Likewise, one can load from a file. In the `readwrite` module, there are functions for handling a variety of file formats. We may also be interested in the *dual* hypergraph formed by considering nodes to be genes and edges to be diseases:"
    ]
   },
   {
@@ -203,24 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "H_disgene = xgi.read_bipartite_edgelist(\"../data/disGene.txt\")\n",
-    "print(f\"The hypergraph has {H_disgene.num_nodes} nodes and {H_disgene.num_edges} edges\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We may also be interested in the *dual* hypergraph formed by considering nodes to be genes and edges to be diseases:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "D = H_disgene.dual()\n",
+    "D = H_enron.dual()\n",
     "print(f\"The hypergraph has {D.num_nodes} nodes and {D.num_edges} edges\")"
    ]
   },
@@ -761,7 +745,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.6 ('venv': venv)",
+   "display_name": "hyper",
    "language": "python",
    "name": "python3"
   },
@@ -775,11 +759,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.6 | packaged by conda-forge | (main, Aug 22 2022, 20:38:29) [Clang 13.0.1 ]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "78db47bee367e3fae825d59af43d695909ce208402094df58551906768c6e91c"
+    "hash": "d499419bfd3ffc3e3fdefe0b9d84e10a93ca5c11fd9f2ad00edb8d726bc70f5f"
    }
   }
  },

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -27,6 +27,7 @@ __all__ = [
     "from_hyperedge_dict",
     "to_hyperedge_dict",
     "from_bipartite_pandas_dataframe",
+    "to_bipartite_pandas_dataframe",
     "from_incidence_matrix",
     "from_simplicial_complex_to_hypergraph",
     "to_incidence_matrix",
@@ -322,6 +323,32 @@ def from_bipartite_pandas_dataframe(
             H.add_node_to_edge(edge, node)
 
     return H
+
+
+def to_bipartite_pandas_dataframe(H):
+    """Create a two column dataframe from a hypergraph.
+
+    Parameters
+    ----------
+    H : Hypergraph or Simplicial Complex
+        A dataframe where specified columns list the node IDs
+        and the associated edge IDs
+
+    Returns
+    -------
+    Pandas Dataframe object
+        A two column dataframe
+
+    Raises
+    ------
+    XGIError
+        Raises an error if the user specifies invalid column names
+    """
+    data = []
+    for id1, members in H._node.items():
+        for id2 in members:
+            data.append([id1, id2])
+    return pd.DataFrame(data, columns=["Node ID", "Edge ID"])
 
 
 def from_incidence_matrix(d, create_using=None, nodelabels=None, edgelabels=None):

--- a/xgi/drawing/xgi_pylab.py
+++ b/xgi/drawing/xgi_pylab.py
@@ -365,7 +365,7 @@ def draw_xgi_hyperedges(
 
     if not max_order:
         max_order = max_edge_order(H)
-        
+
     dyad_color = _color_arg_to_dict(dyad_color, H.edges, settings["dyad_color_cmap"])
     dyad_lw = _scalar_arg_to_dict(
         dyad_lw, H.edges, settings["min_dyad_lw"], settings["max_dyad_lw"]


### PR DESCRIPTION
It was suggested to remove the `data` folder and this PR removes all references to the `disGene.txt` although the dataset remains until it is archived in xgi-data. This PR also adds the `to_bipartite_pandas_dataframe` method.