### PR TITLE
Fix `add_edge()` bug

### DIFF
--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -181,10 +181,10 @@ def test_add_edge():
 
     # check that uid works correctly
     H1 = xgi.Hypergraph()
-    H1.add_edge([1, 2], id=1)
-    H1.add_edge([3, 4])
+    H1.add_edge([1, 2], id=0)
+    H1.add_edge([3, 4], id=2)
     H1.add_edge([5, 6])
-    assert H1._edge == {1: {1, 2}, 2: {3, 4}, 3: {5, 6}}
+    assert H1._edge == {0: {1, 2}, 2: {3, 4}, 3: {5, 6}}
 
     H2 = xgi.Hypergraph()
     H2.add_edge([1, 2])

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -534,7 +534,7 @@ class Hypergraph:
             warn(f"uid {id} already exists, cannot add edge {members}")
             return
 
-        uid = next(self._edge_uid) if not id else id
+        uid = next(self._edge_uid) if id is None else id
 
         self._edge[uid] = set()
         for node in members:


### PR DESCRIPTION
This fixes an error where
```python
import xgi
H = xgi.Hypergraph()
H.add_edge({1, 2, 3}, id=0}
```
returns an empty hypergraph.