### PR TITLE
Line graph and vector centrality functions added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Current version
+
+* Added the `convert_to_line_graph()` function and the `vector_centrality()` function, which uses it (@goznalo-git).
+
 ## v0.5.4
 
 * Fixed issue #270 [#271](https://github.com/ComplexGroupInteractions/xgi/pull/271) (@nwlandry).

--- a/docs/source/api/algorithms/xgi.algorithms.centrality.rst
+++ b/docs/source/api/algorithms/xgi.algorithms.centrality.rst
@@ -11,4 +11,4 @@ xgi.algorithms.centrality
    .. autofunction:: HEC_centrality
    .. autofunction:: ZEC_centrality
    .. autofunction:: node_edge_centrality
-   .. autofunction:: vector_centrality
+   .. autofunction:: line_vector_centrality

--- a/docs/source/api/algorithms/xgi.algorithms.centrality.rst
+++ b/docs/source/api/algorithms/xgi.algorithms.centrality.rst
@@ -11,3 +11,4 @@ xgi.algorithms.centrality
    .. autofunction:: HEC_centrality
    .. autofunction:: ZEC_centrality
    .. autofunction:: node_edge_centrality
+   .. autofunction:: vector_centrality

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -273,7 +273,7 @@ def line_vector_centrality(H):
     """
 
     if not xgi.is_connected(H):
-        raise XGIError("This method is not defined non-connected hypergraphs.")
+        raise XGIError("This method is not defined for non-connected hypergraphs.")
 
     LG = convert_to_line_graph(H)
     LGcent = nx.eigenvector_centrality(LG)

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -285,7 +285,7 @@ def line_vector_centrality(H):
     }
     hyperedge_dims = {tuple(edge): len(edge) for edge in H.edges.members()}
 
-    D = np.max(list(hyperedge_dims.values()))
+    D = H.edges.size.max()
 
     for k in range(2, D + 1):
         c_i = np.zeros(len(H.nodes))

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -253,9 +253,7 @@ def node_edge_centrality(
 
 
 def vector_centrality(H):
-    """
-    Compute the vector centrality of nodes in hypergraphs
-
+    """The vector centrality of nodes in the line graph of the hypergraph.
     Parameters
     ----------
     H : Hypergraph

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -252,7 +252,7 @@ def node_edge_centrality(
     }
 
 
-def vector_centrality(H):
+def line_vector_centrality(H):
     """The vector centrality of nodes in the line graph of the hypergraph.
     Parameters
     ----------

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -280,9 +280,8 @@ def line_vector_centrality(H):
 
     vc = {node: [] for node in H.nodes}
 
-    edge_label_dict = {
-        tuple(edge): index for index, edge in enumerate(H.edges.members())
-    }
+    edge_label_dict = {tuple(edge): index for index, edge in H._edge.items()}
+    
     hyperedge_dims = {tuple(edge): len(edge) for edge in H.edges.members()}
 
     D = H.edges.size.max()

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -157,7 +157,8 @@ def convert_to_line_graph(H):
     edge_label_dict = {
         tuple(edge): index for index, edge in enumerate(H.edges.members())
     }
-    LG.add_nodes_from(edge_label_dict.values())
+    nodes = sorted(set(edge_label_dict.values()))
+    LG.add_nodes_from(nodes)
 
     for edge1, edge2 in combinations(H.edges.members(), 2):
         if edge1.intersection(edge2):

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -154,9 +154,8 @@ def convert_to_line_graph(H):
 
     LG = nx.Graph()
 
-    edge_label_dict = {
-        tuple(edge): index for index, edge in enumerate(H.edges.members())
-    }
+    edge_label_dict = {tuple(edge): index for index, edge in H._edge.items()}
+    
     nodes = sorted(set(edge_label_dict.values()))
     LG.add_nodes_from(nodes)
 

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -134,6 +134,36 @@ def convert_to_graph(H):
     return G
 
 
+def convert_to_line_graph(H):
+    """Line graph of the hypergraph H. This is the graph
+    whose nodes correspond to each hyperedge in H, linked
+    together if they share at least one vertex.
+
+    Parameters
+    ----------
+    H : Hypergraph
+        The hypergraph of interest
+
+    Returns
+    -------
+    LG : networkx.Graph
+         The line graph associated to the Hypergraph
+    """
+
+    LG = nx.Graph()
+
+    edge_label_dict = {
+        tuple(edge): index for index, edge in enumerate(H.edges.members())
+    }
+    LG.add_nodes_from(edge_label_dict.values())
+
+    for edge1, edge2 in combinations(H.edges.members(), 2):
+        if edge1.intersection(edge2):
+            LG.add_edge(edge_label_dict[tuple(edge1)], edge_label_dict[tuple(edge2)])
+
+    return LG
+
+
 def convert_to_simplicial_complex(data, create_using=None):
     """Make a hypergraph from a known data structure.
     The preferred way to call this is automatically

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -135,9 +135,11 @@ def convert_to_graph(H):
 
 
 def convert_to_line_graph(H):
-    """Line graph of the hypergraph H. This is the graph
-    whose nodes correspond to each hyperedge in H, linked
-    together if they share at least one vertex.
+    """Line graph of the hypergraph.
+    
+    The line graph of the hypergraph `H` is the graph whose
+    nodes correspond to each hyperedge in `H`, linked together
+    if they share at least one vertex.
 
     Parameters
     ----------


### PR DESCRIPTION
Hi there, 

I really like this library, and I've been using it for a while now. I would like to have these two additions included, and I'm sure others would benefit from them.
- The function `convert_to_line_graph()` takes a Hypergraph and constructs its associated line graph (a pairwise graph whose nodes correspond to the edges of the Hypergraph, and two of those nodes are linked together if their associated edges share at least one node).
- The function `vector_centrality()`, defined in https://doi.org/10.1016/j.chaos.2022.112397, which allows one to extract a vector-like eigenvector centrality of a Hypergraph by using the abovementioned connection to its line graph. 

I updated the changelog and the docs, as well as making sure the formatting was fine with isort and black.

best,
Gonzalo
