### PR TITLE
Fixed quickstart notebook

### DIFF
--- a/tests/dynamics/test_synchronization.py
+++ b/tests/dynamics/test_synchronization.py
@@ -13,7 +13,7 @@ def test_simulate_kuramoto():
     H1 = xgi.random_hypergraph(N, [0.05, 0.001], seed=0)
     theta_time, times = xgi.simulate_kuramoto(H1, 1, 1, np.ones(N), theta0, n_steps, dt)
 
-    assert theta_time.shape == (N, n_steps)
+    assert theta_time.shape == (n_steps, N)
     assert np.all(times == np.arange(n_steps) * dt)
 
     output = np.array(
@@ -81,7 +81,7 @@ def test_simulate_kuramoto():
         ]
     )
 
-    assert norm(theta_time - output) < 1e-07
+    assert norm(theta_time - output.T) < 1e-07
 
 
 def test_compute_kuramoto_order_parameter():

--- a/tutorials/quickstart.ipynb
+++ b/tutorials/quickstart.ipynb
@@ -185,9 +185,7 @@
     "    multiedges=False, singletons=False, isolates=False, relabel=True, in_place=False\n",
     ")\n",
     "\n",
-    "print(\n",
-    "    f\"The hypergraph has {H_enron_cleaned.num_nodes} nodes and {H_enron_cleaned.num_edges} edges\"\n",
-    ")\n",
+    "print(f\"The hypergraph has {H_enron_cleaned.num_nodes} nodes and {H_enron_cleaned.num_edges} edges\")\n",
     "\n",
     "print(\"The first 10 node IDs are:\")\n",
     "print(list(H_enron_cleaned.nodes)[:10])"
@@ -716,13 +714,15 @@
    "source": [
     "n = 100\n",
     "H = xgi.random_hypergraph(n, [0.05, 0.001], seed=None)\n",
-    "w = 2 * np.random.normal(1, 0.05, n)\n",
+    "omega = 2 * np.random.normal(1, 0.05, n)\n",
     "theta = np.linspace(0, 2 * np.pi, n)\n",
     "timesteps = 1000\n",
-    "dt = 0.002\n",
-    "R = xgi.compute_kuramoto_order_parameter(\n",
-    "    H, k2=2, k3=3, w=w, theta=theta, timesteps=timesteps, dt=dt\n",
-    ")"
+    "dt = 0.01\n",
+    "\n",
+    "theta, t = xgi.simulate_kuramoto(\n",
+    "    H, k2=2, k3=3, omega=omega, theta=theta, timesteps=timesteps, dt=dt\n",
+    ")\n",
+    "R = xgi.compute_kuramoto_order_parameter(theta)"
    ]
   },
   {
@@ -732,7 +732,7 @@
    "outputs": [],
    "source": [
     "plt.figure()\n",
-    "plt.plot(np.arange(0, timesteps * dt, dt), R)\n",
+    "plt.plot(t, R)\n",
     "plt.xlabel(\"time\")\n",
     "plt.ylabel(\"Kuramoto order parameter\")\n",
     "plt.show()"
@@ -762,7 +762,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6 | packaged by conda-forge | (main, Aug 22 2022, 20:38:29) [Clang 13.0.1 ]"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {

--- a/xgi/dynamics/synchronization.py
+++ b/xgi/dynamics/synchronization.py
@@ -40,7 +40,7 @@ def simulate_kuramoto(H, k2, k3, omega=None, theta=None, timesteps=10000, dt=0.0
     Returns
     -------
     theta_time: numpy array of floats
-        Timeseries of phases from the Kuramoto model, of dimension (N, T)
+        Timeseries of phases from the Kuramoto model, of dimension (T, N)
     times: numpy array of floats
         Times corresponding to the simulate phases
 
@@ -67,7 +67,7 @@ def simulate_kuramoto(H, k2, k3, omega=None, theta=None, timesteps=10000, dt=0.0
     triangles = H_int.edges.filterby("size", 3).members()
     n = H_int.num_nodes
 
-    theta_time = np.zeros((n, timesteps))
+    theta_time = np.zeros((timesteps, n))
     times = np.arange(timesteps) * dt
 
     if omega is None:
@@ -78,7 +78,7 @@ def simulate_kuramoto(H, k2, k3, omega=None, theta=None, timesteps=10000, dt=0.0
 
     for t in range(timesteps):
 
-        theta_time[:, t] = theta
+        theta_time[t] = theta
 
         r1 = np.zeros(n, dtype=complex)
         r2 = np.zeros(n, dtype=complex)
@@ -118,7 +118,7 @@ def compute_kuramoto_order_parameter(theta_time):
     Parameters
     ----------
     theta_time: numpy array of floats
-        Timeseries of phases from the Kuramoto model, of dimension (N, T)
+        Timeseries of phases from the Kuramoto model, of dimension (T, N)
 
     Returns
     -------
@@ -127,7 +127,7 @@ def compute_kuramoto_order_parameter(theta_time):
 
     """
 
-    z = np.mean(np.exp(1j * theta_time), axis=0)
+    z = np.mean(np.exp(1j * theta_time), axis=1)
     r_time = np.abs(z)
 
     return r_time


### PR DESCRIPTION
Updated the quickstart notebook and updated the kuramoto function to output theta as a T x N matrix instead of an N x T matrix so that you don't have to transpose the output before plotting.