### PR TITLE
fix: raise error for assortativity of empty hypergraph

### DIFF
--- a/tests/algorithms/test_assortativity.py
+++ b/tests/algorithms/test_assortativity.py
@@ -50,6 +50,15 @@ def test_degree_assortativity(edgelist1, edgelist5):
     assert -1 <= xgi.degree_assortativity(H1, kind="top-2", exact=True) <= 1
     assert -1 <= xgi.degree_assortativity(H1, kind="top-bottom", exact=True) <= 1
 
+    # test empty
+    H = xgi.Hypergraph()
+    with pytest.raises(XGIError):
+        xgi.degree_assortativity(H)
+
+    H.add_nodes_from([0, 1, 2])
+    with pytest.raises(XGIError):
+        xgi.degree_assortativity(H)
+
 
 def test_choose_degrees(edgelist1, edgelist6):
     H1 = xgi.Hypergraph(edgelist1)

--- a/xgi/algorithms/assortativity.py
+++ b/xgi/algorithms/assortativity.py
@@ -82,6 +82,11 @@ def degree_assortativity(H, kind="uniform", exact=False, num_samples=1000):
     float
         the degree assortativity
 
+    Raises
+    ------
+    XGIError
+        If there are no nodes or no edges
+
     References
     ----------
     Phil Chodrow,
@@ -89,6 +94,12 @@ def degree_assortativity(H, kind="uniform", exact=False, num_samples=1000):
     Journal of Complex Networks 2020.
     DOI: 10.1093/comnet/cnaa018
     """
+
+    if H.num_nodes == 0:
+        raise XGIError("Hypergraph must contain nodes")
+    elif H.num_edges == 0:
+        raise XGIError("Hypergraph must contain edges!")
+
     degs = H.degree()
     if exact:
         k1k2 = [

--- a/xgi/algorithms/assortativity.py
+++ b/xgi/algorithms/assortativity.py
@@ -37,8 +37,10 @@ def dynamical_assortativity(H):
     DOI: 10.1063/5.0086905
 
     """
-    if H.num_nodes == 0 or H.num_edges == 0:
-        raise XGIError("Hypergraph must contain nodes and edges!")
+    if H.num_nodes == 0:
+        raise XGIError("Hypergraph must contain nodes")
+    elif H.num_edges == 0:
+        raise XGIError("Hypergraph must contain edges!")
 
     if not is_uniform(H):
         raise XGIError("Hypergraph must be uniform!")


### PR DESCRIPTION
Fix #152 by raising an error in `degree_assortativity` for empty hypergraphs. 
Added a test for it. 

I chose to raise an error to match the behavior of `dynamical_assortativity`. 

We could also choose to return None (if no nodes) and 0/inf/... (if no edges). 