### PR TITLE
Test line graph

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+from networkx import Graph
 
 import xgi
 from xgi.exception import XGIError
@@ -179,3 +180,28 @@ def test_from_bipartite_graph(
     # not bipartite
     with pytest.raises(XGIError):
         H = xgi.from_bipartite_graph(bipartite_graph4, dual=True)
+
+
+def test_to_line_graph(edgelist1, hypergraph1):
+    H = xgi.Hypergraph(edgelist1)
+    L = xgi.to_line_graph(H)
+
+    assert isinstance(L, Graph)
+    assert set(L.nodes) == {0, 1, 2, 3}
+    assert [set(e) for e in L.edges] == [{2, 3}]
+
+    L = xgi.to_line_graph(hypergraph1)
+    assert set(L.nodes) == {"e1", "e2", "e3"}
+    assert [set(e) for e in L.edges] == [{"e1", "e2"}, {"e2", "e3"}]
+
+    H = xgi.Hypergraph()
+    L = xgi.to_line_graph(H)
+
+    assert L.number_of_nodes() == 0
+    assert L.number_of_edges() == 0
+
+    H.add_nodes_from([0, 1, 2])
+    L = xgi.to_line_graph(H)
+
+    assert L.number_of_nodes() == 0
+    assert L.number_of_edges() == 0

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -194,6 +194,14 @@ def test_to_line_graph(edgelist1, hypergraph1):
     assert set(L.nodes) == {"e1", "e2", "e3"}
     assert [set(e) for e in L.edges] == [{"e1", "e2"}, {"e2", "e3"}]
 
+    L = xgi.to_line_graph(hypergraph1,s=2)
+    assert set(L.nodes) == {"e1", "e2", "e3"}
+    assert [set(e) for e in L.edges] == [{"e1", "e2"}]
+
+    L = xgi.to_line_graph(hypergraph1,s=3)
+    assert set(L.nodes) == {"e1", "e2", "e3"}
+    assert [set(e) for e in L.edges] == []
+
     H = xgi.Hypergraph()
     L = xgi.to_line_graph(H)
 

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -7,7 +7,7 @@ from numpy.linalg import norm
 from scipy.sparse.linalg import eigsh
 
 from ..classes import convert_labels_to_integers, is_uniform
-from ..convert import convert_to_line_graph
+from ..convert import to_line_graph
 from ..exception import XGIError
 from ..linalg import clique_motif_matrix, incidence_matrix
 
@@ -267,7 +267,7 @@ def line_vector_centrality(H):
     if not is_connected(H):
         raise XGIError("This method is not defined for disconnected hypergraphs.")
 
-    LG = convert_to_line_graph(H)
+    LG = to_line_graph(H)
     LGcent = nx.eigenvector_centrality(LG)
 
     vc = {node: [] for node in H.nodes}

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -136,8 +136,8 @@ def convert_to_graph(H):
     return G
 
 
-def to_line_graph(H):
-    """Line graph of the hypergraph.
+def to_line_graph(H, s=1):
+    """The s-line graph of the hypergraph.
 
     The line graph of the hypergraph `H` is the graph whose
     nodes correspond to each hyperedge in `H`, linked together
@@ -147,22 +147,30 @@ def to_line_graph(H):
     ----------
     H : Hypergraph
         The hypergraph of interest
+    s : int
+        The intersection size to consider edges
+        as connected, by default 1.
 
     Returns
     -------
     LG : networkx.Graph
          The line graph associated to the Hypergraph
+
+    References
+    ----------
+    "Hypernetwork science via high-order hypergraph walks"
+    by Sinan G. Aksoy, Cliff Joslyn, Carlos Ortiz Marrero, Brenda Praggastis & Emilie Purvine.
+    https://doi.org/10.1140/epjds/s13688-020-00231-0
     """
 
     LG = nx.Graph()
 
     edge_label_dict = {tuple(edge): index for index, edge in H._edge.items()}
 
-    nodes = sorted(set(edge_label_dict.values()))
-    LG.add_nodes_from(nodes)
+    LG.add_nodes_from(H.edges)
 
     for edge1, edge2 in combinations(H.edges.members(), 2):
-        if edge1.intersection(edge2):
+        if len(edge1.intersection(edge2)) >= s:
             LG.add_edge(edge_label_dict[tuple(edge1)], edge_label_dict[tuple(edge2)])
 
     return LG

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -44,6 +44,7 @@ __all__ = [
     "from_bipartite_graph",
     "to_bipartite_graph",
     "dict_to_hypergraph",
+    "to_line_graph",
 ]
 
 
@@ -135,7 +136,7 @@ def convert_to_graph(H):
     return G
 
 
-def convert_to_line_graph(H):
+def to_line_graph(H):
     """Line graph of the hypergraph.
 
     The line graph of the hypergraph `H` is the graph whose


### PR DESCRIPTION
* changed the name from `convert_to_line_graph` to `to_line_graph`.
* added `s-parameter` like in "Hypernetwork science via high-order hypergraph walks"
* added tests

Fixes #298.